### PR TITLE
Add structured policy decisions with deny support

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -52,10 +52,8 @@ func CheckAccess(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Evaluate permissions using the PolicyEngine
-	allowed := policyEngine.Evaluate(req.Subject, req.Resource, req.Action, req.Conditions)
-	fmt.Println("API Response", allowed)
+	decision := policyEngine.Evaluate(req.Subject, req.Resource, req.Action, req.Conditions)
 
 	// Respond with the authorization decision
-	res := map[string]bool{"allowed": allowed}
-	json.NewEncoder(w).Encode(res)
+	json.NewEncoder(w).Encode(decision)
 }

--- a/pkg/policy/decision.go
+++ b/pkg/policy/decision.go
@@ -1,0 +1,9 @@
+package policy
+
+// Decision represents the outcome of a policy evaluation.
+type Decision struct {
+	Allow    bool              `json:"allow"`
+	PolicyID string            `json:"policy_id,omitempty"`
+	Reason   string            `json:"reason"`
+	Context  map[string]string `json:"context,omitempty"`
+}

--- a/pkg/policy/policy_engine_test.go
+++ b/pkg/policy/policy_engine_test.go
@@ -18,7 +18,71 @@ func TestEvaluateSubjectMismatch(t *testing.T) {
 	}
 
 	engine := NewPolicyEngine(store)
-	if engine.Evaluate("user1", "file1", "read", nil) {
+	decision := engine.Evaluate("user1", "file1", "read", nil)
+	if decision.Allow {
 		t.Fatalf("expected evaluation to fail due to subject mismatch")
+	}
+}
+
+func TestEvaluateAllow(t *testing.T) {
+	store := NewPolicyStore()
+	store.Roles["admin"] = Role{Name: "admin", Policies: []string{"policy1"}}
+	store.Users["user1"] = User{Username: "user1", Roles: []string{"admin"}}
+	store.Policies["policy1"] = Policy{
+		ID:       "policy1",
+		Subjects: []Subject{{Role: "admin"}},
+		Resource: []string{"file1"},
+		Action:   []string{"read"},
+		Effect:   "allow",
+	}
+
+	engine := NewPolicyEngine(store)
+	decision := engine.Evaluate("user1", "file1", "read", nil)
+	if !decision.Allow {
+		t.Fatalf("expected evaluation to allow access, got %v", decision)
+	}
+	if decision.PolicyID != "policy1" {
+		t.Fatalf("expected policy1, got %s", decision.PolicyID)
+	}
+}
+
+func TestEvaluateDeny(t *testing.T) {
+	store := NewPolicyStore()
+	store.Roles["admin"] = Role{Name: "admin", Policies: []string{"policy1"}}
+	store.Users["user1"] = User{Username: "user1", Roles: []string{"admin"}}
+	store.Policies["policy1"] = Policy{
+		ID:       "policy1",
+		Subjects: []Subject{{Role: "admin"}},
+		Resource: []string{"file1"},
+		Action:   []string{"read"},
+		Effect:   "deny",
+	}
+
+	engine := NewPolicyEngine(store)
+	decision := engine.Evaluate("user1", "file1", "read", nil)
+	if decision.Allow {
+		t.Fatalf("expected evaluation to deny access, got %v", decision)
+	}
+	if decision.Reason != "denied by policy" {
+		t.Fatalf("expected deny reason, got %s", decision.Reason)
+	}
+}
+
+func TestEvaluateWildcard(t *testing.T) {
+	store := NewPolicyStore()
+	store.Roles["admin"] = Role{Name: "admin", Policies: []string{"policy1"}}
+	store.Users["user1"] = User{Username: "user1", Roles: []string{"admin"}}
+	store.Policies["policy1"] = Policy{
+		ID:       "policy1",
+		Subjects: []Subject{{Role: "admin"}},
+		Resource: []string{"*"},
+		Action:   []string{"*"},
+		Effect:   "allow",
+	}
+
+	engine := NewPolicyEngine(store)
+	decision := engine.Evaluate("user1", "anyfile", "write", nil)
+	if !decision.Allow {
+		t.Fatalf("expected wildcard policy to allow access, got %v", decision)
 	}
 }


### PR DESCRIPTION
## Summary
- return rich Decision objects from the policy engine and `/check-access`
- support `deny` effects and include evaluation context
- add unit tests for allow, deny, wildcard scenarios

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688d4ac777a8832c9a12804ac2ed0439