### PR TITLE
Add policy evaluation trace and explain CLI

### DIFF
--- a/pkg/policy/decision.go
+++ b/pkg/policy/decision.go
@@ -6,4 +6,5 @@ type Decision struct {
 	PolicyID string            `json:"policy_id,omitempty"`
 	Reason   string            `json:"reason"`
 	Context  map[string]string `json:"context,omitempty"`
+	Trace    []string          `json:"trace,omitempty"`
 }


### PR DESCRIPTION
## Summary
- extend Decision with trace of evaluation steps
- track policy matches/failures in PolicyEngine
- add `policyctl explain` command to display policy ID and trace
- test trace output for allow and condition failures

## Testing
- `go vet ./...`
- `go test ./...`
- `go run cmd/policyctl/main.go explain --subject user1 --action read --resource file1`


------
https://chatgpt.com/codex/tasks/task_e_688d55f492a8832c9783f776bbc7f113