### PR TITLE
fix policy engine compile error and make env optional

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -24,15 +23,12 @@ var (
 )
 
 func init() {
-	err := godotenv.Load(".env")
-	if err != nil {
-		fmt.Println("Error loading .env file:", err)
-		panic("Failed to load .env file")
+	if err := godotenv.Load(".env"); err != nil {
+		log.Printf("warning: could not load .env file: %v", err)
 	}
 
 	policyStore = policy.NewPolicyStore()
-	err = policyStore.LoadPolicies(policyFile)
-	if err != nil {
+	if err := policyStore.LoadPolicies(policyFile); err != nil {
 		panic("Failed to load policies: " + err.Error())
 	}
 	policyEngine = policy.NewPolicyEngine(policyStore)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -10,10 +10,9 @@ import (
 )
 
 func main() {
-	// Load environment variables from .env file
-	err := godotenv.Load(".env")
-	if err != nil {
-		log.Fatalf("Error loading .env file: %v", err)
+	// Load environment variables from .env file if present
+	if err := godotenv.Load(".env"); err != nil {
+		log.Printf("warning: could not load .env file: %v", err)
 	}
 
 	// Get the port from the environment variable

--- a/pkg/policy/policy_engine.go
+++ b/pkg/policy/policy_engine.go
@@ -59,8 +59,6 @@ func (pe *PolicyEngine) Evaluate(subject, resource, action string, env map[strin
 				for _, polAction := range policy.Action {
 					if (polResource == "*" || polResource == resource) &&
 						(polAction == "*" || polAction == action) {
-						ok := evaluateConditions(policy.Conditions, env)
-
 						if ok := evaluateConditions(policy.Conditions, env); !ok {
 							return Decision{Allow: false, PolicyID: policy.ID, Reason: "conditions not satisfied", Context: ctx}
 						}


### PR DESCRIPTION
## Summary
- remove unused variable in PolicyEngine Evaluate to resolve compile errors
- load environment variables from `.env` file only when available to avoid startup panics

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688d58d5aca0832c91dcb0d3f7b920c6