### PR TITLE
feat: add docker setup and makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Use the official Go image as a build stage
+FROM golang:1.21-alpine AS builder
+
+WORKDIR /app
+
+# Download dependencies first to leverage caching
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Build the application binary
+RUN go build -o authorization-service ./cmd
+
+# Final runtime image
+FROM alpine:3.18
+
+WORKDIR /app
+
+# Copy executable and configuration
+COPY --from=builder /app/authorization-service ./authorization-service
+COPY configs ./configs
+
+# Default port for the service
+ENV PORT=8080
+EXPOSE 8080
+
+# Run the service
+CMD ["./authorization-service"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+.PHONY: build run test up down logs
+
+APP=authorization-service
+
+build:
+	go build -o $(APP) ./cmd
+
+run:
+	go run ./cmd
+
+test:
+	go test ./...
+
+up:
+	docker compose up --build -d
+
+down:
+	docker compose down
+
+logs:
+	docker compose logs -f

--- a/README.md
+++ b/README.md
@@ -215,19 +215,30 @@ To develop and test the service, follow these steps:
 
 ### Docker Deployment
 
-To build and run the service using Docker:
+The project ships with a `Dockerfile` and a `docker-compose.yml` for running the
+service in a containerized environment.
 
-1. Build the Docker image:
-
-    ```sh
-    docker build -t authorization-service .
-    ```
-
-2. Run the Docker container:
+1. Create a `.env` file in the project root with the required variables
+   (`CLIENT_ID`, `CLIENT_SECRET`, `JWT_SECRET`, `PORT`).
+2. Start the service:
 
     ```sh
-    docker run -d -p 8080:8080 --env-file .env authorization-service
+    docker compose up --build
     ```
+
+3. Stop the service:
+
+    ```sh
+    docker compose down
+    ```
+
+For convenience, a `Makefile` is provided:
+
+```sh
+make up     # Start services using docker compose
+make down   # Stop services
+make test   # Run unit tests
+```
 
 ### Contributing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.8'
+
+services:
+  authorization-service:
+    build: .
+    env_file:
+      - .env
+    ports:
+      - "${PORT:-8080}:${PORT:-8080}"
+    volumes:
+      - ./configs:/app/configs
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile for authorization service
- introduce docker-compose stack for local development
- provide Makefile shortcuts for building, testing, and running services
- document container and Makefile usage in README

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688d5a5fe2e4832cb76ca089200575ee