### PR TITLE
Handle missing .env gracefully

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -23,7 +23,7 @@ var (
 )
 
 func init() {
-	if err := godotenv.Load(".env"); err != nil {
+	if err := godotenv.Load(".env"); err != nil && !os.IsNotExist(err) {
 		log.Printf("warning: could not load .env file: %v", err)
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -10,8 +10,9 @@ import (
 )
 
 func main() {
-	// Load environment variables from .env file if present
-	if err := godotenv.Load(".env"); err != nil {
+	// Load environment variables from .env file if present.
+	// Missing files are ignored to avoid noisy startup warnings.
+	if err := godotenv.Load(".env"); err != nil && !os.IsNotExist(err) {
 		log.Printf("warning: could not load .env file: %v", err)
 	}
 


### PR DESCRIPTION
## Summary
- avoid noisy log messages when `.env` file is absent by only warning on genuine load errors

## Testing
- `go test ./... -count=1`
- `PORT=8080 JWT_SECRET=secret go run cmd/main.go`

------
https://chatgpt.com/codex/tasks/task_e_688d5d83edc4832c8854bf90a9415dee