### PR TITLE
feat: add tenant-scoped policy namespaces

### DIFF
--- a/api/tenant_test.go
+++ b/api/tenant_test.go
@@ -1,0 +1,124 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/bradtumy/authorization-service/pkg/policy"
+)
+
+func TestCheckAccessSingleTenant(t *testing.T) {
+	reqBody := `{"tenantID":"default","subject":"user1","resource":"file1","action":"read","conditions":{}}`
+	r := httptest.NewRequest(http.MethodPost, "/check-access", strings.NewReader(reqBody))
+	w := httptest.NewRecorder()
+	CheckAccess(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	var dec policy.Decision
+	if err := json.NewDecoder(w.Body).Decode(&dec); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !dec.Allow {
+		t.Fatalf("expected allow, got %v", dec)
+	}
+}
+
+func TestCheckAccessMultiTenantIsolation(t *testing.T) {
+	fileA, err := os.CreateTemp("", "tenantA*.yaml")
+	if err != nil {
+		t.Fatalf("tempfile: %v", err)
+	}
+	defer os.Remove(fileA.Name())
+	fileB, err := os.CreateTemp("", "tenantB*.yaml")
+	if err != nil {
+		t.Fatalf("tempfile: %v", err)
+	}
+	defer os.Remove(fileB.Name())
+
+	policyA := `roles:
+- name: "admin"
+  policies: ["p1"]
+users:
+- username: "alice"
+  roles: ["admin"]
+policies:
+- id: "p1"
+  subjects:
+    - role: "admin"
+  resource:
+    - "file1"
+  action:
+    - "read"
+  effect: "allow"
+`
+	if err := os.WriteFile(fileA.Name(), []byte(policyA), 0644); err != nil {
+		t.Fatalf("writeA: %v", err)
+	}
+	policyB := `roles:
+- name: "admin"
+  policies: ["p1"]
+users:
+- username: "alice"
+  roles: ["admin"]
+policies:
+- id: "p1"
+  subjects:
+    - role: "admin"
+  resource:
+    - "file1"
+  action:
+    - "read"
+  effect: "deny"
+`
+	if err := os.WriteFile(fileB.Name(), []byte(policyB), 0644); err != nil {
+		t.Fatalf("writeB: %v", err)
+	}
+
+	storeA := policy.NewPolicyStore()
+	if err := storeA.LoadPolicies(fileA.Name()); err != nil {
+		t.Fatalf("loadA: %v", err)
+	}
+	storeB := policy.NewPolicyStore()
+	if err := storeB.LoadPolicies(fileB.Name()); err != nil {
+		t.Fatalf("loadB: %v", err)
+	}
+	policyStores["tenantA"] = storeA
+	policyEngines["tenantA"] = policy.NewPolicyEngine(storeA)
+	policyFiles["tenantA"] = fileA.Name()
+	policyStores["tenantB"] = storeB
+	policyEngines["tenantB"] = policy.NewPolicyEngine(storeB)
+	policyFiles["tenantB"] = fileB.Name()
+
+	reqA := `{"tenantID":"tenantA","subject":"alice","resource":"file1","action":"read","conditions":{}}`
+	wA := httptest.NewRecorder()
+	rA := httptest.NewRequest(http.MethodPost, "/check-access", strings.NewReader(reqA))
+	CheckAccess(wA, rA)
+	var decA policy.Decision
+	json.NewDecoder(wA.Body).Decode(&decA)
+	if !decA.Allow {
+		t.Fatalf("tenantA expected allow")
+	}
+
+	reqB := `{"tenantID":"tenantB","subject":"alice","resource":"file1","action":"read","conditions":{}}`
+	wB := httptest.NewRecorder()
+	rB := httptest.NewRequest(http.MethodPost, "/check-access", strings.NewReader(reqB))
+	CheckAccess(wB, rB)
+	var decB policy.Decision
+	json.NewDecoder(wB.Body).Decode(&decB)
+	if decB.Allow {
+		t.Fatalf("tenantB expected deny")
+	}
+
+	reqC := `{"tenantID":"missing","subject":"alice","resource":"file1","action":"read","conditions":{}}`
+	wC := httptest.NewRecorder()
+	rC := httptest.NewRequest(http.MethodPost, "/check-access", strings.NewReader(reqC))
+	CheckAccess(wC, rC)
+	if wC.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for unknown tenant, got %d", wC.Code)
+	}
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,8 +5,8 @@
 **Request:**
 
 ```json
-
 {
+  "tenantID": "default",
   "subject": "user1",
   "resource": "file1",
   "action": "read",

--- a/sdk/AuthorizationSDK.js
+++ b/sdk/AuthorizationSDK.js
@@ -1,5 +1,5 @@
-const jwt = require('jsonwebtoken');
-require('dotenv').config();
+const jwt = require("jsonwebtoken");
+require("dotenv").config();
 
 class AuthorizationSDK {
   constructor() {
@@ -13,21 +13,23 @@ class AuthorizationSDK {
       // Add any other necessary claims
     };
 
-    const token = jwt.sign(payload, this.clientSecret, { expiresIn: '1d' });
+    const token = jwt.sign(payload, this.clientSecret, { expiresIn: "1d" });
     return token;
   }
 
-  async evaluatePolicy(subject, resource, action, conditions) {
+  async evaluatePolicy(tenantID, subject, resource, action, conditions) {
     const token = this.generateToken();
 
     // Implement logic to send policy evaluation request
     // Example: use axios or fetch to make an HTTP request to your authorization service
     // Ensure to include the generated token in the request headers
     // Example:
-    // const response = await axios.post('https://your-auth-service/check-access', { subject, resource, action, conditions }, { headers: { Authorization: `Bearer ${token}` } });
+    // const response = await axios.post('https://your-auth-service/check-access', { tenantID, subject, resource, action, conditions }, { headers: { Authorization: `Bearer ${token}` } });
 
     // For simplicity, this example just logs the request details
-    console.log(`Policy Evaluation Request: Subject=${subject}, Resource=${resource}, Action=${action}, Conditions=${conditions}`);
+    console.log(
+      `Policy Evaluation Request: Tenant=${tenantID}, Subject=${subject}, Resource=${resource}, Action=${action}, Conditions=${conditions}`,
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- refactor policy storage into tenant-scoped map and require tenantID on all API requests
- add tenant validation to /check-access, /reload, /compile, and /validate-policy
- document and test single- and multi-tenant behavior

## Testing
- `JWT_SECRET=test POLICY_FILE=../configs/policies.yaml go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688d61359fec832cafb53a264bcd21a2