### PR TITLE
Add tenant management APIs and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ All requests must include a `tenantID` in the JSON body to scope operations.
 | POST   | `/check-access` | Evaluate a tenant-scoped access request         |
 | POST   | `/reload`       | Reload policies for a specific tenant from disk |
 | POST   | `/compile`      | Convert natural language to YAML for a tenant   |
+| POST   | `/tenant/create`| Register a new tenant                            |
+| POST   | `/tenant/delete`| Remove an existing tenant                        |
+| GET    | `/tenant/list`  | List all tenants                                |
 
 #### Generate JWT
 
@@ -121,6 +124,35 @@ curl -X POST http://localhost:8080/check-access \
 ```
 
 Each tenant receives a decision based solely on its own policies.
+
+#### Tenant Lifecycle Management
+
+Use the API or the `policyctl` CLI to create, list, and delete tenants.
+
+**API examples:**
+
+```sh
+curl -X POST http://localhost:8080/tenant/create \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer <JWT>" \
+    -d '{"tenantID":"acme","name":"Acme Inc"}'
+
+curl -H "Authorization: Bearer <JWT>" http://localhost:8080/tenant/list
+
+curl -X POST http://localhost:8080/tenant/delete \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer <JWT>" \
+    -d '{"tenantID":"acme"}'
+```
+
+**CLI examples:**
+
+```sh
+export POLICYCTL_TOKEN=<JWT>
+policyctl tenant create acme
+policyctl tenant list
+policyctl tenant delete acme
+```
 
 #### Modifying Policies
 

--- a/api/tenant_api_test.go
+++ b/api/tenant_api_test.go
@@ -1,0 +1,100 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCreateTenant(t *testing.T) {
+	id := "tenantCreate"
+	body := fmt.Sprintf(`{"tenantID":"%s","name":"%s"}`, id, id)
+	r := httptest.NewRequest(http.MethodPost, "/tenant/create", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	CreateTenant(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	var tenant Tenant
+	if err := json.NewDecoder(w.Body).Decode(&tenant); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if tenant.ID != id {
+		t.Fatalf("expected id %s, got %s", id, tenant.ID)
+	}
+	if store, ok := policyStores[id]; !ok || len(store.Policies) != 0 {
+		t.Fatalf("expected empty policy store for tenant")
+	}
+	// cleanup
+	delBody := fmt.Sprintf(`{"tenantID":"%s"}`, id)
+	dr := httptest.NewRequest(http.MethodPost, "/tenant/delete", strings.NewReader(delBody))
+	dw := httptest.NewRecorder()
+	DeleteTenant(dw, dr)
+}
+
+func TestListTenants(t *testing.T) {
+	id1 := "tenantList1"
+	id2 := "tenantList2"
+	for _, id := range []string{id1, id2} {
+		body := fmt.Sprintf(`{"tenantID":"%s","name":"%s"}`, id, id)
+		r := httptest.NewRequest(http.MethodPost, "/tenant/create", strings.NewReader(body))
+		w := httptest.NewRecorder()
+		CreateTenant(w, r)
+		if w.Code != http.StatusOK {
+			t.Fatalf("create tenant %s failed", id)
+		}
+	}
+	r := httptest.NewRequest(http.MethodGet, "/tenant/list", nil)
+	w := httptest.NewRecorder()
+	ListTenants(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	var list []Tenant
+	if err := json.NewDecoder(w.Body).Decode(&list); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	found1, found2 := false, false
+	for _, tnt := range list {
+		if tnt.ID == id1 {
+			found1 = true
+		}
+		if tnt.ID == id2 {
+			found2 = true
+		}
+	}
+	if !found1 || !found2 {
+		t.Fatalf("expected tenants in list")
+	}
+	// cleanup
+	for _, id := range []string{id1, id2} {
+		delBody := fmt.Sprintf(`{"tenantID":"%s"}`, id)
+		dr := httptest.NewRequest(http.MethodPost, "/tenant/delete", strings.NewReader(delBody))
+		dw := httptest.NewRecorder()
+		DeleteTenant(dw, dr)
+	}
+}
+
+func TestDeleteTenant(t *testing.T) {
+	id := "tenantDelete"
+	createBody := fmt.Sprintf(`{"tenantID":"%s","name":"%s"}`, id, id)
+	cr := httptest.NewRequest(http.MethodPost, "/tenant/create", strings.NewReader(createBody))
+	cw := httptest.NewRecorder()
+	CreateTenant(cw, cr)
+	if cw.Code != http.StatusOK {
+		t.Fatalf("create tenant failed")
+	}
+	delBody := fmt.Sprintf(`{"tenantID":"%s"}`, id)
+	r := httptest.NewRequest(http.MethodPost, "/tenant/delete", strings.NewReader(delBody))
+	w := httptest.NewRecorder()
+	DeleteTenant(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	if _, ok := tenants[id]; ok {
+		t.Fatalf("tenant not deleted")
+	}
+}


### PR DESCRIPTION
## Summary
- introduce in-memory tenant registry with create, delete, and list endpoints
- extend policyctl CLI with tenant lifecycle commands
- document tenant management via API and CLI

## Testing
- `JWT_SECRET=secret POLICY_FILE=../configs/policies.yaml go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688d637b8a64832cb2a51934407cace2