### PR TITLE
Add in-memory relationship graph and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,34 @@ curl -X POST http://localhost:8080/compile \
 go run cmd/policyctl/main.go compile "Mary can approve invoices"
 ```
 
+### Graph Relationships
+
+The authorization service can map relationships between users, groups, and resources. These
+relationships form a directed graph that the evaluator expands when checking access.
+
+#### CLI examples
+
+```
+policyctl graph add user:alice group:managers
+policyctl graph add group:managers resource:server1
+policyctl graph list
+```
+
+#### Sample policy
+
+```
+policies:
+  - id: "manager-read"
+    description: "Managers can read server1"
+    subjects:
+      - role: "managers"
+    resource:
+      - "server1"
+    action:
+      - "read"
+    effect: "allow"
+```
+
 #### Example `policies.yaml`
 
 ```yaml

--- a/api/tenant_test.go
+++ b/api/tenant_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/bradtumy/authorization-service/pkg/graph"
 	"github.com/bradtumy/authorization-service/pkg/policy"
 )
 
@@ -87,11 +88,15 @@ policies:
 	if err := storeB.LoadPolicies(fileB.Name()); err != nil {
 		t.Fatalf("loadB: %v", err)
 	}
+	gA := graph.New()
+	gB := graph.New()
 	policyStores["tenantA"] = storeA
-	policyEngines["tenantA"] = policy.NewPolicyEngine(storeA)
+	policyGraphs["tenantA"] = gA
+	policyEngines["tenantA"] = policy.NewPolicyEngine(storeA, gA)
 	policyFiles["tenantA"] = fileA.Name()
 	policyStores["tenantB"] = storeB
-	policyEngines["tenantB"] = policy.NewPolicyEngine(storeB)
+	policyGraphs["tenantB"] = gB
+	policyEngines["tenantB"] = policy.NewPolicyEngine(storeB, gB)
 	policyFiles["tenantB"] = fileB.Name()
 
 	reqA := `{"tenantID":"tenantA","subject":"alice","resource":"file1","action":"read","conditions":{}}`

--- a/pkg/graph/graph.go
+++ b/pkg/graph/graph.go
@@ -1,0 +1,79 @@
+package graph
+
+import "sync"
+
+// Graph stores directed relationships between entities like users, groups, and resources.
+type Graph struct {
+	mu    sync.RWMutex
+	edges map[string]map[string]struct{}
+}
+
+// New creates a new in-memory graph.
+func New() *Graph {
+	return &Graph{edges: make(map[string]map[string]struct{})}
+}
+
+// AddRelation adds a directed edge from src to dst.
+func (g *Graph) AddRelation(src, dst string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.edges[src] == nil {
+		g.edges[src] = make(map[string]struct{})
+	}
+	g.edges[src][dst] = struct{}{}
+}
+
+// Targets returns the direct targets for a source node.
+func (g *Graph) Targets(src string) []string {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	m := g.edges[src]
+	out := make([]string, 0, len(m))
+	for t := range m {
+		out = append(out, t)
+	}
+	return out
+}
+
+// HasPath determines if there is a path from src to dst using BFS.
+func (g *Graph) HasPath(src, dst string) bool {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	if src == dst {
+		return true
+	}
+	visited := make(map[string]struct{})
+	queue := []string{src}
+	for len(queue) > 0 {
+		n := queue[0]
+		queue = queue[1:]
+		if n == dst {
+			return true
+		}
+		if _, ok := visited[n]; ok {
+			continue
+		}
+		visited[n] = struct{}{}
+		for t := range g.edges[n] {
+			if _, ok := visited[t]; !ok {
+				queue = append(queue, t)
+			}
+		}
+	}
+	return false
+}
+
+// List returns a copy of all edges in the graph.
+func (g *Graph) List() map[string][]string {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	out := make(map[string][]string)
+	for src, targets := range g.edges {
+		arr := make([]string, 0, len(targets))
+		for t := range targets {
+			arr = append(arr, t)
+		}
+		out[src] = arr
+	}
+	return out
+}

--- a/pkg/graph/graph_test.go
+++ b/pkg/graph/graph_test.go
@@ -1,0 +1,19 @@
+package graph
+
+import "testing"
+
+func TestGraphRelationships(t *testing.T) {
+	g := New()
+	g.AddRelation("user:alice", "group:managers")
+	g.AddRelation("group:managers", "resource:db")
+
+	if !g.HasPath("user:alice", "group:managers") {
+		t.Fatalf("expected user to be in group")
+	}
+	if !g.HasPath("group:managers", "resource:db") {
+		t.Fatalf("expected group to relate to resource")
+	}
+	if !g.HasPath("user:alice", "resource:db") {
+		t.Fatalf("expected path from user to resource")
+	}
+}

--- a/pkg/policy/policy_reload_test.go
+++ b/pkg/policy/policy_reload_test.go
@@ -3,6 +3,8 @@ package policy
 import (
 	"os"
 	"testing"
+
+	"github.com/bradtumy/authorization-service/pkg/graph"
 )
 
 // Test that policies can be reloaded from file without restarting service.
@@ -41,7 +43,7 @@ policies:
 	if err := store.LoadPolicies(tmp.Name()); err != nil {
 		t.Fatalf("load policies: %v", err)
 	}
-	engine := NewPolicyEngine(store)
+	engine := NewPolicyEngine(store, graph.New())
 
 	dec := engine.Evaluate("alice", "file1", "read", nil)
 	if dec.Allow {


### PR DESCRIPTION
## Summary
- introduce in-memory graph package for user/group/resource relationships
- expand policy engine to resolve group memberships and resource groups
- add `policyctl graph` subcommands and document relationship graphs

## Testing
- `JWT_SECRET=secret POLICY_FILE=../configs/policies.yaml go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688d66019780832cb362d02e44d79cca