### PR TITLE
feat: support delegation chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,46 @@ relationships form a directed graph that the evaluator expands when checking acc
 ```
 policyctl graph add user:alice group:managers
 policyctl graph add group:managers resource:server1
+policyctl graph delegate alice mary
 policyctl graph list
+```
+
+### Delegation
+
+The relationship graph also supports user-to-user delegation. When a user delegates to another,
+the delegate can act on behalf of the delegator through a chain of delegation edges.
+
+```sh
+# allow alice to act as mary
+policyctl graph delegate alice mary
+```
+
+When `alice` makes a request the evaluator will consider `mary`'s policies if `alice` does not
+have direct access. The resulting decision includes the `delegator` field indicating which user
+granted the effective permission.
+
+**Sample request via delegation:**
+
+```sh
+curl -X POST http://localhost:8080/check-access \
+    -H "Content-Type: application/json" \
+    -d '{"tenantID":"default","subject":"alice","resource":"file1","action":"read"}'
+```
+
+**Sample response:**
+
+```json
+{
+  "allow": true,
+  "policy_id": "policy1",
+  "reason": "allowed by policy",
+  "delegator": "mary",
+  "context": {
+    "subject": "alice",
+    "resource": "file1",
+    "action": "read"
+  }
+}
 ```
 
 #### Sample policy

--- a/cmd/policyctl/main.go
+++ b/cmd/policyctl/main.go
@@ -123,7 +123,7 @@ func handleTenant(args []string) {
 
 func handleGraph(args []string) {
 	if len(args) < 1 {
-		fmt.Println("usage: policyctl graph <add|list> ...")
+		fmt.Println("usage: policyctl graph <add|list|delegate> ...")
 		os.Exit(1)
 	}
 	file := "graph.json"
@@ -137,6 +137,14 @@ func handleGraph(args []string) {
 		g.AddRelation(args[1], args[2])
 		saveGraphFile(file, g)
 		fmt.Println("relationship added")
+	case "delegate":
+		if len(args) < 3 {
+			fmt.Println("usage: policyctl graph delegate <delegator> <delegatee>")
+			os.Exit(1)
+		}
+		g.AddRelation("user:"+args[1], "user:"+args[2])
+		saveGraphFile(file, g)
+		fmt.Println("delegation added")
 	case "list":
 		rels := g.List()
 		for src, targets := range rels {
@@ -145,7 +153,7 @@ func handleGraph(args []string) {
 			}
 		}
 	default:
-		fmt.Println("usage: policyctl graph <add|list> ...")
+		fmt.Println("usage: policyctl graph <add|list|delegate> ...")
 		os.Exit(1)
 	}
 }

--- a/pkg/policy/decision.go
+++ b/pkg/policy/decision.go
@@ -2,8 +2,9 @@ package policy
 
 // Decision represents the outcome of a policy evaluation.
 type Decision struct {
-	Allow    bool              `json:"allow"`
-	PolicyID string            `json:"policy_id,omitempty"`
-	Reason   string            `json:"reason"`
-	Context  map[string]string `json:"context,omitempty"`
+	Allow     bool              `json:"allow"`
+	PolicyID  string            `json:"policy_id,omitempty"`
+	Reason    string            `json:"reason"`
+	Context   map[string]string `json:"context,omitempty"`
+	Delegator string            `json:"delegator,omitempty"`
 }

--- a/pkg/policy/policy_engine.go
+++ b/pkg/policy/policy_engine.go
@@ -32,63 +32,100 @@ func (pe *PolicyEngine) Evaluate(subject, resource, action string, env map[strin
 		"action":   action,
 	}
 
-	user, exists := pe.store.Users[subject]
-	if !exists {
-		return Decision{Allow: false, Reason: "user not found", Context: ctx}
-	}
-
-	// Gather roles from user definition and graph-based group memberships.
-	roles := append([]string{}, user.Roles...)
+	// Collect candidate subjects including delegation chain.
+	subjects := []string{subject}
 	if pe.graph != nil {
-		for _, target := range pe.graph.Targets("user:" + subject) {
-			if strings.HasPrefix(target, "group:") {
-				roles = append(roles, strings.TrimPrefix(target, "group:"))
+		queue := []string{subject}
+		visited := map[string]struct{}{subject: struct{}{}}
+		for len(queue) > 0 {
+			s := queue[0]
+			queue = queue[1:]
+			for _, t := range pe.graph.Targets("user:" + s) {
+				if strings.HasPrefix(t, "user:") {
+					u := strings.TrimPrefix(t, "user:")
+					if _, ok := visited[u]; !ok {
+						visited[u] = struct{}{}
+						subjects = append(subjects, u)
+						queue = append(queue, u)
+					}
+				}
 			}
 		}
 	}
 
-	for _, roleName := range roles {
-		role, exists := pe.store.Roles[roleName]
+	for idx, subj := range subjects {
+		user, exists := pe.store.Users[subj]
 		if !exists {
+			if idx == 0 {
+				return Decision{Allow: false, Reason: "user not found", Context: ctx}
+			}
 			continue
 		}
 
-		for _, policyID := range role.Policies {
-			policy, exists := pe.store.Policies[policyID]
+		// Gather roles from user definition and graph-based group memberships.
+		roles := append([]string{}, user.Roles...)
+		if pe.graph != nil {
+			for _, target := range pe.graph.Targets("user:" + subj) {
+				if strings.HasPrefix(target, "group:") {
+					roles = append(roles, strings.TrimPrefix(target, "group:"))
+				}
+			}
+		}
+
+		for _, roleName := range roles {
+			role, exists := pe.store.Roles[roleName]
 			if !exists {
 				continue
 			}
-			// Ensure the policy applies to the current role
-			if len(policy.Subjects) > 0 {
-				allowed := false
-				for _, subj := range policy.Subjects {
-					if subj.Role == roleName {
-						allowed = true
-						break
-					}
-				}
-				if !allowed {
+
+			for _, policyID := range role.Policies {
+				policy, exists := pe.store.Policies[policyID]
+				if !exists {
 					continue
 				}
-			}
-
-			for _, polResource := range policy.Resource {
-				matchResource := polResource == "*" || polResource == resource
-				if !matchResource && pe.graph != nil {
-					if pe.graph.HasPath("group:"+polResource, "resource:"+resource) {
-						matchResource = true
+				// Ensure the policy applies to the current role
+				if len(policy.Subjects) > 0 {
+					allowed := false
+					for _, subjRole := range policy.Subjects {
+						if subjRole.Role == roleName {
+							allowed = true
+							break
+						}
+					}
+					if !allowed {
+						continue
 					}
 				}
-				for _, polAction := range policy.Action {
-					if matchResource && (polAction == "*" || polAction == action) {
-						if ok := evaluateConditions(policy.Conditions, env); !ok {
-							return Decision{Allow: false, PolicyID: policy.ID, Reason: "conditions not satisfied", Context: ctx}
+
+				for _, polResource := range policy.Resource {
+					matchResource := polResource == "*" || polResource == resource
+					if !matchResource && pe.graph != nil {
+						if pe.graph.HasPath("group:"+polResource, "resource:"+resource) {
+							matchResource = true
 						}
-						switch policy.Effect {
-						case "allow":
-							return Decision{Allow: true, PolicyID: policy.ID, Reason: "allowed by policy", Context: ctx}
-						case "deny":
-							return Decision{Allow: false, PolicyID: policy.ID, Reason: "denied by policy", Context: ctx}
+					}
+					for _, polAction := range policy.Action {
+						if matchResource && (polAction == "*" || polAction == action) {
+							if ok := evaluateConditions(policy.Conditions, env); !ok {
+								dec := Decision{Allow: false, PolicyID: policy.ID, Reason: "conditions not satisfied", Context: ctx}
+								if subj != subject {
+									dec.Delegator = subj
+								}
+								return dec
+							}
+							dec := Decision{PolicyID: policy.ID, Context: ctx}
+							if subj != subject {
+								dec.Delegator = subj
+							}
+							switch policy.Effect {
+							case "allow":
+								dec.Allow = true
+								dec.Reason = "allowed by policy"
+							case "deny":
+								dec.Allow = false
+								dec.Reason = "denied by policy"
+							}
+							return dec
 						}
 					}
 				}


### PR DESCRIPTION
## Summary
- allow evaluating delegation chains and track delegator
- add `policyctl graph delegate` command
- document delegation usage and sample flows

## Testing
- `JWT_SECRET=test POLICY_FILE=../configs/policies.yaml go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688d682154c4832cbad09ba6297e8747