### PR TITLE
test: assert delegator on invalid delegation

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,9 @@ When `alice` makes a request the evaluator will consider `mary`'s policies if `a
 have direct access. The resulting decision includes the `delegator` field indicating which user
 granted the effective permission.
 
+If no applicable policies exist along the chain, the request is denied and the `delegator` field
+is omitted from the response.
+
 **Sample request via delegation:**
 
 ```sh

--- a/pkg/policy/policy_engine_test.go
+++ b/pkg/policy/policy_engine_test.go
@@ -215,9 +215,12 @@ func TestEvaluateDelegationChainInvalid(t *testing.T) {
 	g := graph.New()
 	g.AddRelation("user:alice", "user:mary")
 
-	engine := NewPolicyEngine(store, g)
-	dec := engine.Evaluate("alice", "file1", "read", nil)
-	if dec.Allow {
-		t.Fatalf("expected delegation chain to deny access, got %#v", dec)
-	}
+        engine := NewPolicyEngine(store, g)
+        dec := engine.Evaluate("alice", "file1", "read", nil)
+       if dec.Allow {
+               t.Fatalf("expected delegation chain to deny access, got %#v", dec)
+       }
+       if dec.Delegator != "" {
+               t.Fatalf("unexpected delegator %q for failed delegation", dec.Delegator)
+       }
 }


### PR DESCRIPTION
## Summary
- document delegation failure behavior and returned decision
- test that failed delegation chains do not report a delegator

## Testing
- `JWT_SECRET=foo POLICY_FILE=../configs/policies.yaml go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688d6b0bbb3c832ca6625a109d3fb7e9