### PR TITLE
Add tenant list audit logging and document structured logs

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -362,9 +362,21 @@ func DeleteTenant(w http.ResponseWriter, r *http.Request) {
 func ListTenants(w http.ResponseWriter, r *http.Request) {
 	list, err := backend.ListTenants(r.Context())
 	if err != nil {
+		auditLogger.Log(logger.Entry{
+			Level:         "error",
+			CorrelationID: middleware.CorrelationIDFromContext(r.Context()),
+			Action:        "tenant_list",
+			Reason:        err.Error(),
+		})
 		http.Error(w, "failed to list tenants", http.StatusInternalServerError)
 		return
 	}
+	auditLogger.Log(logger.Entry{
+		Level:         "info",
+		CorrelationID: middleware.CorrelationIDFromContext(r.Context()),
+		Action:        "tenant_list",
+		Decision:      "success",
+	})
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(list)
 }


### PR DESCRIPTION
## Summary
- add audit logging for tenant list endpoint using structured logger
- document JSON log fields, examples, and log level configuration in README

## Testing
- `go test ./...` *(fails: Failed to load policies: open configs/policies.yaml: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688e923b2bdc832caa08fa9db25a00fc