### PR TITLE
Add Helm chart for Kubernetes deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Binaries
-authorization-service
+/authorization-service
 *.exe
 *.out
 

--- a/README.md
+++ b/README.md
@@ -542,6 +542,28 @@ make down   # Stop services
 make test   # Run unit tests
 ```
 
+### Helm Deployment
+
+A Helm chart is available in `helm/authorization-service` for deploying the service to Kubernetes clusters such as Minikube or Kind.
+
+1. Copy the provided `helm/authorization-service/example-values.yaml` and adjust it for your environment.
+2. Install the chart:
+
+   ```sh
+   helm install authz helm/authorization-service -f values.yaml
+   ```
+
+   Image repository, tag, replica count, service port, OIDC settings, policy backend, resources, and additional environment variables or secrets can be overridden via the values file or `--set` flags.
+
+Example inline overrides:
+
+```sh
+helm install authz helm/authorization-service \
+  --set image.repository=myrepo/authorization-service \
+  --set image.tag=v1.0.0 \
+  --set service.port=9090
+```
+
 ### Contributing
 
 Contributions are welcome! Please open an issue or submit a pull request.

--- a/helm/authorization-service/Chart.yaml
+++ b/helm/authorization-service/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: authorization-service
+description: Helm chart for deploying the Authorization Service
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/helm/authorization-service/example-values.yaml
+++ b/helm/authorization-service/example-values.yaml
@@ -1,0 +1,31 @@
+replicaCount: 2
+
+image:
+  repository: myrepo/authorization-service
+  tag: v1.2.3
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 9090
+
+policyBackend: sqlite
+
+oidc:
+  clientID: my-client-id
+  clientSecret: my-client-secret
+  issuers: https://issuer.example.com
+  audiences: my-client-id
+
+env:
+  LOG_LEVEL: debug
+secretEnv:
+  EXTRA_SECRET: topsecret
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi

--- a/helm/authorization-service/templates/_helpers.tpl
+++ b/helm/authorization-service/templates/_helpers.tpl
@@ -1,0 +1,25 @@
+{{- define "authorization-service.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "authorization-service.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "authorization-service.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" -}}
+{{- end -}}
+
+{{- define "authorization-service.labels" -}}
+helm.sh/chart: {{ include "authorization-service.chart" . }}
+app.kubernetes.io/name: {{ include "authorization-service.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "authorization-service.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "authorization-service.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/helm/authorization-service/templates/deployment.yaml
+++ b/helm/authorization-service/templates/deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "authorization-service.fullname" . }}
+  labels:
+    {{- include "authorization-service.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "authorization-service.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "authorization-service.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.port }}
+          env:
+            - name: PORT
+              value: "{{ .Values.service.port }}"
+            - name: STORE_BACKEND
+              value: "{{ .Values.policyBackend }}"
+            - name: OIDC_ISSUERS
+              value: "{{ .Values.oidc.issuers }}"
+            - name: OIDC_AUDIENCES
+              value: "{{ .Values.oidc.audiences }}"
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
+            {{- end }}
+          {{- if or .Values.oidc.clientID .Values.oidc.clientSecret .Values.secretEnv }}
+          envFrom:
+            - secretRef:
+                name: {{ include "authorization-service.fullname" . }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/helm/authorization-service/templates/secret.yaml
+++ b/helm/authorization-service/templates/secret.yaml
@@ -1,0 +1,17 @@
+{{- if or .Values.oidc.clientID .Values.oidc.clientSecret .Values.secretEnv }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "authorization-service.fullname" . }}
+type: Opaque
+stringData:
+  {{- if .Values.oidc.clientID }}
+  CLIENT_ID: {{ .Values.oidc.clientID | quote }}
+  {{- end }}
+  {{- if .Values.oidc.clientSecret }}
+  CLIENT_SECRET: {{ .Values.oidc.clientSecret | quote }}
+  {{- end }}
+  {{- range $key, $value := .Values.secretEnv }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/helm/authorization-service/templates/service.yaml
+++ b/helm/authorization-service/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "authorization-service.fullname" . }}
+  labels:
+    {{- include "authorization-service.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "authorization-service.selectorLabels" . | nindent 4 }}

--- a/helm/authorization-service/values.yaml
+++ b/helm/authorization-service/values.yaml
@@ -1,0 +1,23 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/example/authorization-service
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 8080
+
+policyBackend: memory
+
+oidc:
+  clientID: ""
+  clientSecret: ""
+  issuers: ""
+  audiences: ""
+
+env: {}
+secretEnv: {}
+
+resources: {}


### PR DESCRIPTION
## Summary
- add Helm chart for deploying authorization-service
- document Helm installation in README
- adjust gitignore for chart tracking

## Testing
- `go test ./...`
- attempted to install `helm` but installation failed: HTTP 403 from get.helm.sh


------
https://chatgpt.com/codex/tasks/task_e_6890c35dd1d0832c9f738eb66e998958