### PR TITLE
Add Go & Python SDKs with examples and Postman collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,34 @@ All requests must include a `tenantID` in the JSON body to scope operations.
 | POST   | `/tenant/delete`| Remove an existing tenant                        |
 | GET    | `/tenant/list`  | List all tenants                                |
 
+### SDK Usage
+
+#### Go
+
+```go
+client := sdk.NewClient("http://localhost:8080")
+decision, err := client.CheckAccess(sdk.AccessRequest{
+    TenantID: "default",
+    Subject:  "alice",
+    Resource: "file1",
+    Action:   "read",
+})
+if err != nil {
+    panic(err)
+}
+fmt.Println(decision.Allow)
+```
+
+#### Python
+
+```python
+from authorization import Client
+
+client = Client("http://localhost:8080")
+decision = client.check_access("default", "alice", "file1", "read")
+print(decision["allow"])
+```
+
 ### Observability
 
 The service emits structured JSON logs for every request. Each log entry contains the

--- a/docs/authorization-service.postman_collection.json
+++ b/docs/authorization-service.postman_collection.json
@@ -1,0 +1,89 @@
+{
+  "info": {
+    "name": "Authorization Service",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Check Access",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"tenantID\": \"default\",\n  \"subject\": \"alice\",\n  \"resource\": \"file1\",\n  \"action\": \"read\"\n}"
+        },
+        "url": {
+          "raw": "{{baseUrl}}/check-access",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "check-access"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Compile Rule",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"tenantID\": \"default\",\n  \"rule\": \"allow alice to read file1\"\n}"
+        },
+        "url": {
+          "raw": "{{baseUrl}}/compile",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "compile"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Validate Policy",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"tenantID\": \"default\",\n  \"policy\": \"policies: []\"\n}"
+        },
+        "url": {
+          "raw": "{{baseUrl}}/validate-policy",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "validate-policy"
+          ]
+        }
+      }
+    }
+  ],
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "http://localhost:8080"
+    }
+  ]
+}

--- a/sdk/go/example/main.go
+++ b/sdk/go/example/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"fmt"
+
+	sdk "github.com/bradtumy/authorization-service/sdk/go"
+)
+
+func main() {
+	client := sdk.NewClient("http://localhost:8080")
+	decision, err := client.CheckAccess(sdk.AccessRequest{
+		TenantID: "default",
+		Subject:  "alice",
+		Resource: "file1",
+		Action:   "read",
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("allow:", decision.Allow)
+}

--- a/sdk/go/sdk.go
+++ b/sdk/go/sdk.go
@@ -1,0 +1,88 @@
+package sdk
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+type Client struct {
+	BaseURL    string
+	HTTPClient *http.Client
+}
+
+func NewClient(baseURL string) *Client {
+	return &Client{BaseURL: baseURL, HTTPClient: &http.Client{}}
+}
+
+type AccessRequest struct {
+	TenantID   string            `json:"tenantID"`
+	Subject    string            `json:"subject"`
+	Resource   string            `json:"resource"`
+	Action     string            `json:"action"`
+	Conditions map[string]string `json:"conditions,omitempty"`
+}
+
+type Decision struct {
+	Allow    bool   `json:"allow"`
+	PolicyID string `json:"policyID"`
+	Reason   string `json:"reason"`
+}
+
+func (c *Client) post(path string, payload any) (*http.Response, error) {
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	url := fmt.Sprintf("%s%s", c.BaseURL, path)
+	return c.HTTPClient.Post(url, "application/json", bytes.NewReader(b))
+}
+
+func (c *Client) CheckAccess(req AccessRequest) (*Decision, error) {
+	resp, err := c.post("/check-access", req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+	var dec Decision
+	if err := json.NewDecoder(resp.Body).Decode(&dec); err != nil {
+		return nil, err
+	}
+	return &dec, nil
+}
+
+func (c *Client) CompileRule(tenantID, rule string) (string, error) {
+	resp, err := c.post("/compile", map[string]string{"tenantID": tenantID, "rule": rule})
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
+func (c *Client) ValidatePolicy(tenantID, policy string) error {
+	resp, err := c.post("/validate-policy", map[string]string{"tenantID": tenantID, "policy": policy})
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}

--- a/sdk/go/sdk_test.go
+++ b/sdk/go/sdk_test.go
@@ -1,0 +1,43 @@
+package sdk
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type checkAccessResponse struct {
+	Allow    bool   `json:"allow"`
+	PolicyID string `json:"policyID"`
+	Reason   string `json:"reason"`
+}
+
+func TestClient(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/check-access", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(checkAccessResponse{Allow: true, PolicyID: "p1", Reason: "ok"})
+	})
+	mux.HandleFunc("/compile", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("policy: allow"))
+	})
+	mux.HandleFunc("/validate-policy", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("policy is valid"))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	dec, err := c.CheckAccess(AccessRequest{TenantID: "t", Subject: "s", Resource: "r", Action: "a"})
+	if err != nil || !dec.Allow {
+		t.Fatalf("CheckAccess failed: %v", err)
+	}
+	if _, err := c.CompileRule("t", "rule"); err != nil {
+		t.Fatalf("CompileRule failed: %v", err)
+	}
+	if err := c.ValidatePolicy("t", "policy"); err != nil {
+		t.Fatalf("ValidatePolicy failed: %v", err)
+	}
+}

--- a/sdk/python/authorization.py
+++ b/sdk/python/authorization.py
@@ -1,0 +1,44 @@
+import json
+from urllib import request
+
+
+class Client:
+    def __init__(self, base_url: str):
+        self.base_url = base_url.rstrip('/')
+
+    def _post(self, path: str, data: dict) -> tuple[int, str]:
+        payload = json.dumps(data).encode('utf-8')
+        req = request.Request(
+            self.base_url + path,
+            data=payload,
+            headers={'Content-Type': 'application/json'},
+            method='POST',
+        )
+        with request.urlopen(req) as resp:
+            body = resp.read().decode('utf-8')
+            return resp.status, body
+
+    def check_access(self, tenant_id: str, subject: str, resource: str, action: str, conditions: dict | None = None) -> dict:
+        status, body = self._post('/check-access', {
+            'tenantID': tenant_id,
+            'subject': subject,
+            'resource': resource,
+            'action': action,
+            'conditions': conditions or {},
+        })
+        if status != 200:
+            raise RuntimeError(f'unexpected status {status}: {body}')
+        return json.loads(body)
+
+    def compile_rule(self, tenant_id: str, rule: str) -> str:
+        status, body = self._post('/compile', {'tenantID': tenant_id, 'rule': rule})
+        if status != 200:
+            raise RuntimeError(f'unexpected status {status}: {body}')
+        return body
+
+    def validate_policy(self, tenant_id: str, policy: str) -> str:
+        status, body = self._post('/validate-policy', {'tenantID': tenant_id, 'policy': policy})
+        if status != 200:
+            raise RuntimeError(f'unexpected status {status}: {body}')
+        return body
+

--- a/sdk/python/example.py
+++ b/sdk/python/example.py
@@ -1,0 +1,5 @@
+from authorization import Client
+
+client = Client('http://localhost:8080')
+result = client.check_access('default', 'alice', 'file1', 'read')
+print(result)

--- a/sdk/python/test_authorization.py
+++ b/sdk/python/test_authorization.py
@@ -1,0 +1,61 @@
+import json
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+from authorization import Client
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        if self.path == '/check-access':
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self.wfile.write(b'{"allow": true, "policyID": "p1", "reason": "ok"}')
+        elif self.path == '/compile':
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b'policy: allow')
+        elif self.path == '/validate-policy':
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b'policy is valid')
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+
+class TestClient(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.server = HTTPServer(('localhost', 0), Handler)
+        cls.port = cls.server.server_address[1]
+        cls.thread = threading.Thread(target=cls.server.serve_forever)
+        cls.thread.setDaemon(True)
+        cls.thread.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.thread.join()
+
+    def setUp(self):
+        self.client = Client(f'http://localhost:{self.port}')
+
+    def test_check_access(self):
+        decision = self.client.check_access('t', 's', 'r', 'a')
+        self.assertTrue(decision['allow'])
+
+    def test_compile_rule(self):
+        yaml = self.client.compile_rule('t', 'rule')
+        self.assertIn('policy', yaml)
+
+    def test_validate_policy(self):
+        resp = self.client.validate_policy('t', 'policy')
+        self.assertIn('valid', resp)
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- Implement Go and Python SDK clients with CheckAccess, CompileRule and ValidatePolicy helpers
- Provide example apps and unit tests for each SDK
- Add Postman collection entries and document SDK usage in README

## Testing
- `POLICY_FILE=../configs/policies.yaml go test ./api ./sdk/go ./pkg/... ./internal/...`
- `POLICY_FILE=../../configs/policies.yaml go test ./tests/integration`
- `python -m unittest discover -s sdk/python -p 'test*.py'`


------
https://chatgpt.com/codex/tasks/task_e_6890c975397c832c9d3e3b4ae4169df0