### PR TITLE
Add metrics validation tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,27 @@ scrape_configs:
 The exporter publishes `http_requests_total`, `http_request_duration_seconds`, and
 `policy_eval_count` metrics.
 
+#### Validating Metrics Locally
+
+1. Start the service:
+
+```sh
+POLICY_FILE=configs/policies.yaml go run cmd/main.go
+```
+
+2. In another terminal, issue a request and inspect the metrics:
+
+```sh
+curl -H 'Authorization: Bearer test' \
+  -H 'Content-Type: application/json' \
+  -d '{"tenantID":"default","subject":"user1","resource":"file1","action":"read","conditions":{}}' \
+  http://localhost:8080/check-access
+curl -H 'Authorization: Bearer test' http://localhost:8080/metrics
+```
+
+The metrics output will show counters such as `http_requests_total` and
+`policy_eval_count`, along with latency histograms for each path.
+
 #### Tracing
 
 Distributed traces are emitted via OpenTelemetry. Run a local Jaeger instance and point

--- a/api/metrics_test.go
+++ b/api/metrics_test.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+import _ "unsafe"
+
+//go:linkname httpLatency github.com/bradtumy/authorization-service/internal/middleware.httpLatency
+var httpLatency *prometheus.HistogramVec
+
+func TestMetricsHandlerRecordsLatency(t *testing.T) {
+	router := SetupRouter()
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	req.Header.Set("Authorization", "Bearer test")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	obs, err := httpLatency.GetMetricWithLabelValues("/metrics")
+	if err != nil {
+		t.Fatalf("get metric: %v", err)
+	}
+	m := &dto.Metric{}
+	if err := obs.(prometheus.Metric).Write(m); err != nil {
+		t.Fatalf("metric write: %v", err)
+	}
+	if m.GetHistogram().GetSampleCount() == 0 {
+		t.Fatalf("expected histogram sample count > 0")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/mattn/go-sqlite3 v1.14.30
 	github.com/prometheus/client_golang v1.23.0
+	github.com/prometheus/client_model v0.6.2
 	go.opentelemetry.io/otel v1.37.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.37.0
 	go.opentelemetry.io/otel/sdk v1.37.0
@@ -28,8 +29,8 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.65.0 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect

--- a/tests/integration/metrics_test.go
+++ b/tests/integration/metrics_test.go
@@ -1,0 +1,85 @@
+package integration
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	api "github.com/bradtumy/authorization-service/api"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+import _ "unsafe"
+
+//go:linkname policyEval github.com/bradtumy/authorization-service/api.policyEval
+var policyEval *prometheus.CounterVec
+
+//go:linkname httpRequests github.com/bradtumy/authorization-service/internal/middleware.httpRequests
+var httpRequests *prometheus.CounterVec
+
+func setupServer(t *testing.T) (*httptest.Server, string) {
+	t.Helper()
+	router := api.SetupRouter()
+	srv := httptest.NewServer(router)
+	tok := token(t)
+	t.Cleanup(srv.Close)
+	return srv, tok
+}
+
+func makeCheckRequest(t *testing.T, srv *httptest.Server, tok, body string) {
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/check-access", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+tok)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status %d", resp.StatusCode)
+	}
+}
+
+func TestCheckAccessRequestCounter(t *testing.T) {
+	srv, tok := setupServer(t)
+	before := testutil.ToFloat64(httpRequests.WithLabelValues("/check-access"))
+	body := `{"tenantID":"default","subject":"user1","resource":"file1","action":"read","conditions":{}}`
+	makeCheckRequest(t, srv, tok, body)
+	after := testutil.ToFloat64(httpRequests.WithLabelValues("/check-access"))
+	if after != before+1 {
+		t.Fatalf("expected http_requests_total to increment by 1, before %v after %v", before, after)
+	}
+	// metrics endpoint should be reachable
+	mreq, _ := http.NewRequest(http.MethodGet, srv.URL+"/metrics", nil)
+	mreq.Header.Set("Authorization", "Bearer "+tok)
+	mresp, err := http.DefaultClient.Do(mreq)
+	if err != nil {
+		t.Fatalf("metrics: %v", err)
+	}
+	mresp.Body.Close()
+	if mresp.StatusCode != http.StatusOK {
+		t.Fatalf("metrics status %d", mresp.StatusCode)
+	}
+}
+
+func TestPolicyEvalCounters(t *testing.T) {
+	srv, tok := setupServer(t)
+	allowBefore := testutil.ToFloat64(policyEval.WithLabelValues("allow"))
+	denyBefore := testutil.ToFloat64(policyEval.WithLabelValues("deny"))
+
+	allowBody := `{"tenantID":"default","subject":"user1","resource":"file1","action":"read","conditions":{}}`
+	denyBody := `{"tenantID":"default","subject":"user2","resource":"file3","action":"edit","conditions":{}}`
+	makeCheckRequest(t, srv, tok, allowBody)
+	makeCheckRequest(t, srv, tok, denyBody)
+
+	allowAfter := testutil.ToFloat64(policyEval.WithLabelValues("allow"))
+	denyAfter := testutil.ToFloat64(policyEval.WithLabelValues("deny"))
+	if allowAfter != allowBefore+1 {
+		t.Fatalf("expected policy_eval_count allow to increment, before %v after %v", allowBefore, allowAfter)
+	}
+	if denyAfter != denyBefore+1 {
+		t.Fatalf("expected policy_eval_count deny to increment, before %v after %v", denyBefore, denyAfter)
+	}
+}


### PR DESCRIPTION
## Summary
- add integration tests verifying http request and policy evaluation counters
- check /metrics handler records latency
- document how to validate metrics locally

## Testing
- `POLICY_FILE=/workspace/authorization-service/configs/policies.yaml go test ./...`
- `curl -s -H 'Authorization: Bearer test' http://localhost:8080/metrics | grep -E 'http_requests_total|policy_eval_count' -n`


------
https://chatgpt.com/codex/tasks/task_e_6890d18a0eb4832cacd98ddc08135472