### PR TITLE
Add governance and security policy documentation

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,17 @@
+# Governance
+
+This document outlines how the project is governed.
+
+## Pull Request Review
+
+* All pull requests require at least one approval from a maintainer before merge.
+* Continuous integration checks must pass before changes are merged.
+* Substantial or breaking changes should be discussed in an issue before a pull request is opened.
+
+## Maintainer Responsibilities
+
+* Triage issues and pull requests in a timely manner.
+* Ensure code quality and adherence to project guidelines.
+* Maintain documentation and release new versions.
+* Uphold the project's Code of Conduct.
+

--- a/README.md
+++ b/README.md
@@ -682,6 +682,14 @@ helm install authz helm/authorization-service \
 
 Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
+### Governance
+
+Project roles, maintainer responsibilities, and review processes are documented in [GOVERNANCE.md](GOVERNANCE.md).
+
+### Security
+
+For information on reporting vulnerabilities, please see [SECURITY.md](SECURITY.md).
+
 ### Code of Conduct
 
 Please read our [Code of Conduct](CODE_OF_CONDUCT.md) to understand the expectations for participants in this project.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please email **opensource@bradtumy.com** with details.
+
+We will investigate and respond as quickly as possible. Please do not publicly disclose the issue until we have addressed it.
+
+## Supported Versions
+
+Security fixes are applied to the latest main branch. Please upgrade to the newest release to ensure you have the latest patches.
+


### PR DESCRIPTION
## Summary
- add project governance guidelines
- document vulnerability reporting process
- link governance and security docs from README

## Testing
- `POLICY_FILE=$(pwd)/configs/policies.yaml go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6890f3df29b0832ca275c00b84602b1b