### PR TITLE
Add project roadmap and contributor entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Authorization Service is an open-source authorization service that reads policie
 - [Architecture](docs/ARCHITECTURE.md)
 - [Flows](docs/flows.md)
 - [API Reference](docs/api.md)
+- [Roadmap](ROADMAP.md)
 
 ## Quickstart
 
@@ -715,6 +716,7 @@ helm install authz helm/authorization-service \
 ## Contributing
 
 Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+New contributors can start with our [good first issues](https://github.com/bradtumy/authorization-service/issues?q=is%3Aopen+label%3A%22good+first+issue%22).
 
 ## How to file issues
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,14 @@
+# Roadmap
+
+The project continues to evolve through incremental MVPs. Upcoming milestones focus on richer context handling and AI assistance.
+
+## MVP G – Context & Risk Awareness
+- Incorporate contextual signals such as location, device posture, and time to refine authorization decisions.
+- Evaluate risk levels and adapt policies dynamically.
+- Expose configuration knobs to tune context weighting and risk thresholds.
+
+## MVP H – AI-Assisted Policy Authoring
+- Integrate AI helpers to suggest or generate policy rules from natural language prompts.
+- Provide an interactive flow for reviewing and approving AI-generated policies before activation.
+- Capture feedback to continuously improve policy suggestions.
+


### PR DESCRIPTION
## Summary
- document upcoming MVP G (context & risk awareness) and MVP H (AI-assisted policy authoring) in new ROADMAP
- link to roadmap and "good first issues" from README to guide contributors

## Testing
- `make test` *(fails: open configs/policies.yaml: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68910578e9b4832cbf00d76520b0b254