### PR TITLE
feat: add when policy conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,17 +518,20 @@ curl -X POST http://localhost:8080/check-access \
 
 #### Sample policy
 
-```
+```yaml
 policies:
-  - id: "manager-read"
-    description: "Managers can read server1"
+  - id: "partner-access"
+    description: "Partners can view the dashboard during business hours if risk is low"
     subjects:
-      - role: "managers"
+      - role: "partner"
     resource:
-      - "server1"
+      - "dashboard"
     action:
-      - "read"
+      - "view"
     effect: "allow"
+    when:
+      - context.time == "business-hours"
+      - context.risk < "medium"
 ```
 
 #### Example `policies.yaml`

--- a/pkg/policy/conditions.go
+++ b/pkg/policy/conditions.go
@@ -1,10 +1,13 @@
 package policy
 
-import "time"
+import (
+	"strconv"
+	"strings"
+	"time"
+)
 
 // now is a variable for mocking current time in tests.
 var now = time.Now
-
 
 // evaluateConditions checks whether all policy conditions are satisfied using
 // the provided environment values.
@@ -30,6 +33,95 @@ func evaluateConditions(policyConds map[string]string, env map[string]string) bo
 		}
 	}
 	return true
+}
+
+// evaluateWhen evaluates a list of boolean expressions against the environment.
+// Supported operators are ==, <, and >. Expressions must reference context
+// values using the form `context.key`.
+func evaluateWhen(exprs []string, env map[string]string) bool {
+	if len(exprs) == 0 {
+		return true
+	}
+	for _, expr := range exprs {
+		if !evaluateExpression(expr, env) {
+			return false
+		}
+	}
+	return true
+}
+
+// evaluateExpression parses and evaluates a single expression.
+func evaluateExpression(expr string, env map[string]string) bool {
+	expr = strings.TrimSpace(expr)
+	var op string
+	var parts []string
+	if strings.Contains(expr, "==") {
+		op = "=="
+		parts = strings.SplitN(expr, "==", 2)
+	} else if strings.Contains(expr, ">") {
+		op = ">"
+		parts = strings.SplitN(expr, ">", 2)
+	} else if strings.Contains(expr, "<") {
+		op = "<"
+		parts = strings.SplitN(expr, "<", 2)
+	} else {
+		return false
+	}
+	if len(parts) != 2 {
+		return false
+	}
+	left := strings.TrimSpace(parts[0])
+	right := strings.TrimSpace(parts[1])
+	right = strings.Trim(right, "'\"")
+	if !strings.HasPrefix(left, "context.") {
+		return false
+	}
+	key := strings.TrimPrefix(left, "context.")
+	val, ok := env[key]
+	if !ok {
+		return false
+	}
+	switch op {
+	case "==":
+		return val == right
+	case "<", ">":
+		return compareValues(val, right, op)
+	}
+	return false
+}
+
+// compareValues compares two values using the provided operator. It attempts
+// numeric comparison, then known risk level ordering, and finally falls back to
+// lexical string comparison.
+func compareValues(left, right, op string) bool {
+	if lf, err := strconv.ParseFloat(left, 64); err == nil {
+		if rf, err := strconv.ParseFloat(right, 64); err == nil {
+			switch op {
+			case "<":
+				return lf < rf
+			case ">":
+				return lf > rf
+			}
+		}
+	}
+	order := map[string]int{"low": 1, "medium": 2, "high": 3}
+	if lv, ok := order[strings.ToLower(left)]; ok {
+		if rv, ok := order[strings.ToLower(right)]; ok {
+			switch op {
+			case "<":
+				return lv < rv
+			case ">":
+				return lv > rv
+			}
+		}
+	}
+	switch op {
+	case "<":
+		return left < right
+	case ">":
+		return left > right
+	}
+	return false
 }
 
 // evaluateTimeCondition evaluates the "time" condition. The expected value

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -25,4 +25,5 @@ type Policy struct {
 	Action      []string          `yaml:"action"`
 	Effect      string            `yaml:"effect"`
 	Conditions  map[string]string `yaml:"conditions"`
+	When        []string          `yaml:"when"`
 }

--- a/pkg/policy/policy_engine.go
+++ b/pkg/policy/policy_engine.go
@@ -116,6 +116,13 @@ func (pe *PolicyEngine) Evaluate(subject, resource, action string, env map[strin
 								}
 								return dec
 							}
+							if ok := evaluateWhen(policy.When, env); !ok {
+								dec := Decision{Allow: false, PolicyID: policy.ID, Reason: "conditions not satisfied", Context: ctx}
+								if subj != subject {
+									dec.Delegator = subj
+								}
+								return dec
+							}
 							dec := Decision{PolicyID: policy.ID, Context: ctx}
 							if subj != subject {
 								dec.Delegator = subj

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -30,6 +30,7 @@ type policy struct {
 	Action      []string          `yaml:"action"`
 	Effect      string            `yaml:"effect"`
 	Conditions  map[string]string `yaml:"conditions"`
+	When        []string          `yaml:"when"`
 }
 
 // Config represents the structure of the policy file.


### PR DESCRIPTION
## Summary
- support `when` expressions in policy schema
- evaluate context-based expressions with <, ==, >
- document when syntax with risk/time example

## Testing
- `POLICY_FILE=$(pwd)/configs/policies.yaml go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68910ed28370832c8ab1758821371e6a