### PR TITLE
feat: extend observability for context-aware evaluations

### DIFF
--- a/api/metrics_test.go
+++ b/api/metrics_test.go
@@ -3,13 +3,18 @@ package api
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
+	_ "unsafe"
 )
 
-import _ "unsafe"
+func init() {
+	os.Setenv("OIDC_CONFIG_FILE", "/dev/null")
+	os.Setenv("POLICY_FILE", "../configs/policies.yaml")
+}
 
 //go:linkname httpLatency github.com/bradtumy/authorization-service/internal/middleware.httpLatency
 var httpLatency *prometheus.HistogramVec

--- a/pkg/policy/policy_engine.go
+++ b/pkg/policy/policy_engine.go
@@ -117,15 +117,15 @@ func (pe *PolicyEngine) Evaluate(subject, resource, action string, env map[strin
 					}
 					for _, polAction := range policy.Action {
 						if matchResource && (polAction == "*" || polAction == action) {
-							if ok := evaluateConditions(policy.Conditions, env); !ok {
-								dec := Decision{Allow: false, PolicyID: policy.ID, Reason: "conditions not satisfied", Context: ctx}
+							if ok, reason := evaluateConditions(policy.Conditions, env); !ok {
+								dec := Decision{Allow: false, PolicyID: policy.ID, Reason: reason, Context: ctx}
 								if subj != subject {
 									dec.Delegator = subj
 								}
 								return addRemediation(dec)
 							}
-							if ok := evaluateWhen(policy.When, env); !ok {
-								dec := Decision{Allow: false, PolicyID: policy.ID, Reason: "conditions not satisfied", Context: ctx}
+							if ok, reason := evaluateWhen(policy.When, env); !ok {
+								dec := Decision{Allow: false, PolicyID: policy.ID, Reason: reason, Context: ctx}
 								if subj != subject {
 									dec.Delegator = subj
 								}

--- a/pkg/policy/policy_engine_test.go
+++ b/pkg/policy/policy_engine_test.go
@@ -129,7 +129,7 @@ func TestEvaluateConditionUnsatisfied(t *testing.T) {
 	if decision.Allow {
 		t.Fatalf("expected access to be denied outside business hours")
 	}
-	if decision.Reason != "conditions not satisfied" {
+	if decision.Reason != "time" {
 		t.Fatalf("unexpected reason: %s", decision.Reason)
 	}
 	if len(decision.Remediation) == 0 || decision.Remediation[0] != "Try again during working hours" {
@@ -175,7 +175,7 @@ func TestEvaluateWhenUnsatisfied(t *testing.T) {
 	if decision.Allow {
 		t.Fatalf("expected access to be denied when when conditions not satisfied")
 	}
-	if decision.Reason != "conditions not satisfied" {
+	if decision.Reason != "risk" {
 		t.Fatalf("unexpected reason: %s", decision.Reason)
 	}
 	if len(decision.Remediation) == 0 || decision.Remediation[0] != "Require MFA step-up" {

--- a/tests/integration/metrics_test.go
+++ b/tests/integration/metrics_test.go
@@ -70,16 +70,16 @@ func TestCheckAccessRequestCounter(t *testing.T) {
 
 func TestPolicyEvalCounters(t *testing.T) {
 	srv, tok := setupServer(t)
-	allowBefore := testutil.ToFloat64(policyEval.WithLabelValues("allow"))
-	denyBefore := testutil.ToFloat64(policyEval.WithLabelValues("deny"))
+	allowBefore := testutil.ToFloat64(policyEval.WithLabelValues("allow", ""))
+	denyBefore := testutil.ToFloat64(policyEval.WithLabelValues("deny", "other"))
 
 	allowBody := `{"tenantID":"default","subject":"user1","resource":"file1","action":"read","conditions":{}}`
 	denyBody := `{"tenantID":"default","subject":"user2","resource":"file3","action":"edit","conditions":{}}`
 	makeCheckRequest(t, srv, tok, allowBody)
 	makeCheckRequest(t, srv, tok, denyBody)
 
-	allowAfter := testutil.ToFloat64(policyEval.WithLabelValues("allow"))
-	denyAfter := testutil.ToFloat64(policyEval.WithLabelValues("deny"))
+	allowAfter := testutil.ToFloat64(policyEval.WithLabelValues("allow", ""))
+	denyAfter := testutil.ToFloat64(policyEval.WithLabelValues("deny", "other"))
 	if allowAfter != allowBefore+1 {
 		t.Fatalf("expected policy_eval_count allow to increment, before %v after %v", allowBefore, allowAfter)
 	}

--- a/tests/integration/persistence_test.go
+++ b/tests/integration/persistence_test.go
@@ -66,7 +66,7 @@ func startServer(t *testing.T) *httptest.Server {
 	policyEval = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "policy_eval_count",
 		Help: "Number of policy evaluations",
-	}, []string{"decision"})
+	}, []string{"decision", "reason"})
 	prometheus.MustRegister(policyEval)
 
 	var err error


### PR DESCRIPTION
## Summary
- add `reason` label to policy evaluation metrics to highlight risk/time denials
- trace context gathering and record decision reasons for policy evaluations
- document observability features and context-aware metrics

## Testing
- `POLICY_FILE=/workspace/authorization-service/configs/policies.yaml OIDC_CONFIG_FILE=/dev/null go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68925c2b1360832c9beddb5264f719c3