### PR TITLE
docs: update Postman collection

### DIFF
--- a/postman/authorization-service.postman_collection.json
+++ b/postman/authorization-service.postman_collection.json
@@ -78,6 +78,125 @@
           ]
         }
       }
+    },
+    {
+      "name": "Simulate Access",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"tenantID\": \"default\",\n  \"subject\": \"alice\",\n  \"resource\": \"file1\",\n  \"action\": \"read\",\n  \"context\": {}\n}"
+        },
+        "url": {
+          "raw": "{{baseUrl}}/simulate",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "simulate"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Reload Policies",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"tenantID\": \"default\"\n}"
+        },
+        "url": {
+          "raw": "{{baseUrl}}/reload",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "reload"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Create Tenant",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"tenantID\": \"tenant1\",\n  \"name\": \"Tenant One\"\n}"
+        },
+        "url": {
+          "raw": "{{baseUrl}}/tenant/create",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "tenant",
+            "create"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Delete Tenant",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"tenantID\": \"tenant1\"\n}"
+        },
+        "url": {
+          "raw": "{{baseUrl}}/tenant/delete",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "tenant",
+            "delete"
+          ]
+        }
+      }
+    },
+    {
+      "name": "List Tenants",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/tenant/list",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "tenant",
+            "list"
+          ]
+        }
+      }
     }
   ],
   "variable": [


### PR DESCRIPTION
## Summary
- expand Postman collection with endpoints for simulate access, policy reload, and tenant management

## Testing
- `POLICY_FILE=$(pwd)/configs/policies.yaml go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68934955f538832cb34ea6d0d804a625