### PR TITLE
feat: add user management api

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,28 @@ curl -s -X POST http://localhost:8080/check-access \
 
 Examples live in [`examples/`](examples) and the Postman collection in [`postman/`](postman).
 
+## Managing Users Dynamically via API
+
+Users and their roles can be managed at runtime using the User Management API. All requests require a bearer token from a user with either the `TenantAdmin` or `PolicyAdmin` role.
+
+Create a user:
+
+```sh
+curl -X POST http://localhost:8080/user/create \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer <token>' \
+  -d '{"tenantID":"acme","username":"bob"}'
+```
+
+List users:
+
+```sh
+curl -H 'Authorization: Bearer <token>' \
+  'http://localhost:8080/user/list?tenantID=acme'
+```
+
+Additional endpoints support assigning roles, deleting users and fetching a single user. See [docs/users.md](docs/users.md) for details.
+
 ## License
 
 Apache 2.0 licensed. See [LICENSE](LICENSE).

--- a/api/api.go
+++ b/api/api.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
 	"os"
@@ -16,7 +17,9 @@ import (
 	"github.com/bradtumy/authorization-service/pkg/policycompiler"
 	"github.com/bradtumy/authorization-service/pkg/store"
 	"github.com/bradtumy/authorization-service/pkg/tenant"
+	"github.com/bradtumy/authorization-service/pkg/user"
 	"github.com/bradtumy/authorization-service/pkg/validator"
+	jwt "github.com/golang-jwt/jwt/v4"
 	"github.com/gorilla/mux"
 	"github.com/joho/godotenv"
 	"github.com/prometheus/client_golang/prometheus"
@@ -24,6 +27,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+	"strings"
 )
 
 var (
@@ -73,6 +77,14 @@ func init() {
 	defaultFile := os.Getenv("POLICY_FILE")
 	if defaultFile == "" {
 		defaultFile = "configs/policies.yaml"
+	}
+	if _, err := os.Stat(defaultFile); os.IsNotExist(err) {
+		for _, alt := range []string{"../" + defaultFile, "../../" + defaultFile} {
+			if _, err2 := os.Stat(alt); err2 == nil {
+				defaultFile = alt
+				break
+			}
+		}
 	}
 
 	store := policy.NewPolicyStore()
@@ -147,6 +159,54 @@ type ValidatePolicyRequest struct {
 	Policy   string `json:"policy"`
 }
 
+type CreateUserRequest struct {
+	TenantID string   `json:"tenantID"`
+	Username string   `json:"username"`
+	Roles    []string `json:"roles"`
+}
+
+type AssignRoleRequest struct {
+	TenantID string   `json:"tenantID"`
+	Username string   `json:"username"`
+	Roles    []string `json:"roles"`
+}
+
+type DeleteUserRequest struct {
+	TenantID string `json:"tenantID"`
+	Username string `json:"username"`
+}
+
+func subjectFromRequest(r *http.Request) (string, error) {
+	auth := r.Header.Get("Authorization")
+	if auth == "" {
+		return "", errors.New("missing token")
+	}
+	tokenString := strings.TrimPrefix(auth, "Bearer ")
+	claims := jwt.MapClaims{}
+	parser := jwt.Parser{}
+	if _, _, err := parser.ParseUnverified(tokenString, claims); err != nil {
+		return "", err
+	}
+	sub, _ := claims["sub"].(string)
+	if sub == "" {
+		return "", errors.New("missing subject")
+	}
+	return sub, nil
+}
+
+func requireAdmin(w http.ResponseWriter, r *http.Request, tenantID string) (string, bool) {
+	sub, err := subjectFromRequest(r)
+	if err != nil {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return "", false
+	}
+	if !user.HasRole(tenantID, sub, "TenantAdmin", "PolicyAdmin") {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return "", false
+	}
+	return sub, true
+}
+
 func SetupRouter() *mux.Router {
 	router := mux.NewRouter()
 	router.Use(middleware.TracingMiddleware)
@@ -161,6 +221,11 @@ func SetupRouter() *mux.Router {
 	router.HandleFunc("/tenant/create", CreateTenant).Methods("POST")
 	router.HandleFunc("/tenant/delete", DeleteTenant).Methods("POST")
 	router.HandleFunc("/tenant/list", ListTenants).Methods("GET")
+	router.HandleFunc("/user/create", CreateUser).Methods("POST")
+	router.HandleFunc("/user/assign-role", AssignRole).Methods("POST")
+	router.HandleFunc("/user/delete", DeleteUser).Methods("POST")
+	router.HandleFunc("/user/list", ListUsers).Methods("GET")
+	router.HandleFunc("/user/get", GetUser).Methods("GET")
 	router.Handle("/metrics", promhttp.Handler()).Methods("GET")
 	return router
 }
@@ -499,4 +564,92 @@ func ListTenants(w http.ResponseWriter, r *http.Request) {
 	})
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(list)
+}
+
+// CreateUser creates a new user under a tenant.
+func CreateUser(w http.ResponseWriter, r *http.Request) {
+	var req CreateUserRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if _, ok := requireAdmin(w, r, req.TenantID); !ok {
+		return
+	}
+	u, err := user.Create(req.TenantID, req.Username, req.Roles)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(u)
+}
+
+// AssignRole assigns roles to an existing user.
+func AssignRole(w http.ResponseWriter, r *http.Request) {
+	var req AssignRoleRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if _, ok := requireAdmin(w, r, req.TenantID); !ok {
+		return
+	}
+	if err := user.AssignRoles(req.TenantID, req.Username, req.Roles); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+// DeleteUser removes a user from the system.
+func DeleteUser(w http.ResponseWriter, r *http.Request) {
+	var req DeleteUserRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if _, ok := requireAdmin(w, r, req.TenantID); !ok {
+		return
+	}
+	if err := user.Delete(req.TenantID, req.Username); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+// ListUsers returns all users for a tenant.
+func ListUsers(w http.ResponseWriter, r *http.Request) {
+	tenantID := r.URL.Query().Get("tenantID")
+	if tenantID == "" {
+		http.Error(w, "missing tenantID", http.StatusBadRequest)
+		return
+	}
+	if _, ok := requireAdmin(w, r, tenantID); !ok {
+		return
+	}
+	list := user.List(tenantID)
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(list)
+}
+
+// GetUser returns information for a specific user.
+func GetUser(w http.ResponseWriter, r *http.Request) {
+	tenantID := r.URL.Query().Get("tenantID")
+	username := r.URL.Query().Get("username")
+	if tenantID == "" || username == "" {
+		http.Error(w, "missing tenantID or username", http.StatusBadRequest)
+		return
+	}
+	if _, ok := requireAdmin(w, r, tenantID); !ok {
+		return
+	}
+	u, err := user.Get(tenantID, username)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(u)
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,16 +2,21 @@ package main
 
 import (
 	"context"
+	"flag"
 	"log"
 	"net/http"
 	"os"
 
 	"github.com/bradtumy/authorization-service/api"
 	"github.com/bradtumy/authorization-service/internal/telemetry"
+	"github.com/bradtumy/authorization-service/pkg/user"
 	"github.com/joho/godotenv"
 )
 
 func main() {
+	persistUsers := flag.Bool("persist-users", false, "persist users to configs/<tenantID>/users.yaml")
+	flag.Parse()
+
 	// Load environment variables from .env file if present.
 	// Missing files are ignored to avoid noisy startup warnings.
 	if err := godotenv.Load(".env"); err != nil && !os.IsNotExist(err) {
@@ -31,6 +36,7 @@ func main() {
 	}
 	defer func() { _ = shutdown(ctx) }()
 
+	user.EnablePersistence(*persistUsers)
 	router := api.SetupRouter()
 	log.Println("Starting server on :", port)
 	log.Fatal(http.ListenAndServe(":"+port, router))

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -33,3 +33,6 @@ Policy evaluation counters are exported as `policy_eval_count{decision,reason}`.
 
 ## Notes & Caveats
 Malformed policies will be rejected at load time; use `policy validate` to detect issues early.
+
+## Managing Users
+Roles referenced in policies are assigned to users dynamically. Manage users and their roles via the [User API](users.md).

--- a/docs/users.md
+++ b/docs/users.md
@@ -1,0 +1,46 @@
+# Users
+
+## Overview
+Users encapsulate principals within a tenant and hold zero or more roles. The service exposes endpoints for managing users dynamically at runtime.
+
+## API Usage
+Create a user:
+```sh
+curl -X POST http://localhost:8080/user/create \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer <token>' \
+  -d '{"tenantID":"acme","username":"alice","roles":["TenantAdmin"]}'
+```
+Assign roles:
+```sh
+curl -X POST http://localhost:8080/user/assign-role \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer <token>' \
+  -d '{"tenantID":"acme","username":"alice","roles":["PolicyAdmin"]}'
+```
+Delete a user:
+```sh
+curl -X POST http://localhost:8080/user/delete \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer <token>' \
+  -d '{"tenantID":"acme","username":"alice"}'
+```
+List users for a tenant:
+```sh
+curl -H 'Authorization: Bearer <token>' \
+  'http://localhost:8080/user/list?tenantID=acme'
+```
+Get a specific user:
+```sh
+curl -H 'Authorization: Bearer <token>' \
+  'http://localhost:8080/user/get?tenantID=acme&username=alice'
+```
+
+## Authorization
+All endpoints require an `Authorization: Bearer <token>` header. Only callers with the `TenantAdmin` or `PolicyAdmin` role within the target tenant may invoke these APIs.
+
+## CLI Usage
+No dedicated CLI commands exist yet; use the API examples above or integrate via the SDK.
+
+## Persistence
+Run the server with `--persist-users` to store users under `configs/<tenantID>/users.yaml`.

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.37.0
 	gopkg.in/go-jose/go-jose.v2 v2.6.3
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/pkg/user/user.go
+++ b/pkg/user/user.go
@@ -1,0 +1,170 @@
+package user
+
+import (
+	"errors"
+	"os"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+// User represents a system user scoped to a tenant.
+type User struct {
+	Username string   `json:"username" yaml:"username"`
+	Roles    []string `json:"roles" yaml:"roles"`
+	TenantID string   `json:"tenantID" yaml:"-"`
+}
+
+var (
+	mu      sync.RWMutex
+	users   = make(map[string][]User) // tenantID -> []User
+	loaded  = make(map[string]bool)
+	persist bool
+)
+
+// EnablePersistence toggles writing users to disk under configs/<tenantID>/users.yaml.
+func EnablePersistence(p bool) { persist = p }
+
+// filePath returns the persistence path for a tenant.
+func filePath(tenantID string) string {
+	return "configs/" + tenantID + "/users.yaml"
+}
+
+// load ensures users for a tenant are loaded from disk if persistence is enabled.
+func load(tenantID string) {
+	if !persist || loaded[tenantID] {
+		return
+	}
+	path := filePath(tenantID)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		loaded[tenantID] = true
+		return
+	}
+	var wrapper struct {
+		Users []User `yaml:"users"`
+	}
+	if err := yaml.Unmarshal(data, &wrapper); err == nil {
+		for i := range wrapper.Users {
+			wrapper.Users[i].TenantID = tenantID
+		}
+		users[tenantID] = wrapper.Users
+	}
+	loaded[tenantID] = true
+}
+
+// save persists users for a tenant if enabled.
+func save(tenantID string) {
+	if !persist {
+		return
+	}
+	path := filePath(tenantID)
+	if err := os.MkdirAll("configs/"+tenantID, 0755); err != nil {
+		return
+	}
+	wrapper := struct {
+		Users []User `yaml:"users"`
+	}{Users: users[tenantID]}
+	data, err := yaml.Marshal(wrapper)
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(path, data, 0644)
+}
+
+// Create adds a new user under a tenant.
+func Create(tenantID, username string, roles []string) (User, error) {
+	mu.Lock()
+	defer mu.Unlock()
+	load(tenantID)
+	for _, u := range users[tenantID] {
+		if u.Username == username {
+			return User{}, errors.New("user exists")
+		}
+	}
+	u := User{Username: username, Roles: roles, TenantID: tenantID}
+	users[tenantID] = append(users[tenantID], u)
+	save(tenantID)
+	return u, nil
+}
+
+// AssignRoles sets roles for an existing user.
+func AssignRoles(tenantID, username string, roles []string) error {
+	mu.Lock()
+	defer mu.Unlock()
+	load(tenantID)
+	for i, u := range users[tenantID] {
+		if u.Username == username {
+			users[tenantID][i].Roles = roles
+			save(tenantID)
+			return nil
+		}
+	}
+	return errors.New("user not found")
+}
+
+// Delete removes a user from the tenant.
+func Delete(tenantID, username string) error {
+	mu.Lock()
+	defer mu.Unlock()
+	load(tenantID)
+	arr := users[tenantID]
+	for i, u := range arr {
+		if u.Username == username {
+			users[tenantID] = append(arr[:i], arr[i+1:]...)
+			save(tenantID)
+			return nil
+		}
+	}
+	return errors.New("user not found")
+}
+
+// List returns all users for a tenant.
+func List(tenantID string) []User {
+	mu.RLock()
+	defer mu.RUnlock()
+	load(tenantID)
+	list := users[tenantID]
+	cp := make([]User, len(list))
+	copy(cp, list)
+	return cp
+}
+
+// Get returns a user by username.
+func Get(tenantID, username string) (User, error) {
+	mu.RLock()
+	defer mu.RUnlock()
+	load(tenantID)
+	for _, u := range users[tenantID] {
+		if u.Username == username {
+			return u, nil
+		}
+	}
+	return User{}, errors.New("user not found")
+}
+
+// HasRole checks if a user has any of the provided roles.
+func HasRole(tenantID, username string, roles ...string) bool {
+	u, err := Get(tenantID, username)
+	if err != nil {
+		return false
+	}
+	roleSet := make(map[string]struct{}, len(u.Roles))
+	for _, r := range u.Roles {
+		roleSet[r] = struct{}{}
+	}
+	for _, r := range roles {
+		if _, ok := roleSet[r]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// Reset clears all users (used in tests).
+func Reset() {
+	mu.Lock()
+	defer mu.Unlock()
+	users = make(map[string][]User)
+	loaded = make(map[string]bool)
+}

--- a/pkg/user/user_test.go
+++ b/pkg/user/user_test.go
@@ -1,0 +1,31 @@
+package user
+
+import "testing"
+
+func TestCRUD(t *testing.T) {
+	Reset()
+	EnablePersistence(false)
+	if _, err := Create("acme", "alice", []string{"TenantAdmin"}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if !HasRole("acme", "alice", "TenantAdmin") {
+		t.Fatalf("alice missing role")
+	}
+	if err := AssignRoles("acme", "alice", []string{"PolicyAdmin"}); err != nil {
+		t.Fatalf("assign: %v", err)
+	}
+	u, err := Get("acme", "alice")
+	if err != nil || len(u.Roles) != 1 || u.Roles[0] != "PolicyAdmin" {
+		t.Fatalf("get after assign")
+	}
+	list := List("acme")
+	if len(list) != 1 || list[0].Username != "alice" {
+		t.Fatalf("list incorrect")
+	}
+	if err := Delete("acme", "alice"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := Get("acme", "alice"); err == nil {
+		t.Fatalf("expected not found")
+	}
+}

--- a/postman/authorization-service.postman_collection.json
+++ b/postman/authorization-service.postman_collection.json
@@ -197,6 +197,100 @@
           ]
         }
       }
+    },
+    {
+      "name": "Create User",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"tenantID\": \"default\",\n  \"username\": \"bob\",\n  \"roles\": [\"viewer\"]\n}"
+        },
+        "url": {
+          "raw": "{{baseUrl}}/user/create",
+          "host": ["{{baseUrl}}"],
+          "path": ["user", "create"]
+        }
+      }
+    },
+    {
+      "name": "Assign Role",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"tenantID\": \"default\",\n  \"username\": \"bob\",\n  \"roles\": [\"editor\"]\n}"
+        },
+        "url": {
+          "raw": "{{baseUrl}}/user/assign-role",
+          "host": ["{{baseUrl}}"],
+          "path": ["user", "assign-role"]
+        }
+      }
+    },
+    {
+      "name": "Delete User",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"tenantID\": \"default\",\n  \"username\": \"bob\"\n}"
+        },
+        "url": {
+          "raw": "{{baseUrl}}/user/delete",
+          "host": ["{{baseUrl}}"],
+          "path": ["user", "delete"]
+        }
+      }
+    },
+    {
+      "name": "List Users",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/user/list?tenantID=default",
+          "host": ["{{baseUrl}}"],
+          "path": ["user", "list"],
+          "query": [
+            {"key": "tenantID", "value": "default"}
+          ]
+        }
+      }
+    },
+    {
+      "name": "Get User",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/user/get?tenantID=default&username=bob",
+          "host": ["{{baseUrl}}"],
+          "path": ["user", "get"],
+          "query": [
+            {"key": "tenantID", "value": "default"},
+            {"key": "username", "value": "bob"}
+          ]
+        }
+      }
     }
   ],
   "variable": [

--- a/tests/integration/user_api_test.go
+++ b/tests/integration/user_api_test.go
@@ -1,0 +1,117 @@
+package integration
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	api "github.com/bradtumy/authorization-service/api"
+	"github.com/bradtumy/authorization-service/internal/middleware"
+	"github.com/bradtumy/authorization-service/pkg/user"
+	jwt "github.com/golang-jwt/jwt/v4"
+)
+
+func tokenFor(t *testing.T, sub string) string {
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"sub": sub})
+	str, err := tok.SignedString([]byte("secret"))
+	if err != nil {
+		t.Fatalf("token: %v", err)
+	}
+	return str
+}
+
+func TestUserAPI(t *testing.T) {
+	os.Setenv("OIDC_CONFIG_FILE", "/dev/null")
+	middleware.LoadOIDCConfig()
+	user.Reset()
+	user.EnablePersistence(false)
+	if _, err := user.Create("default", "admin", []string{"TenantAdmin"}); err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	router := api.SetupRouter()
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	adminTok := tokenFor(t, "admin")
+
+	// create bob
+	body := `{"tenantID":"default","username":"bob","roles":["viewer"]}`
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/user/create", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+adminTok)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		t.Fatalf("create user: %v status %d", err, resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	// assign role
+	body = `{"tenantID":"default","username":"bob","roles":["editor"]}`
+	req, _ = http.NewRequest(http.MethodPost, srv.URL+"/user/assign-role", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+adminTok)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		t.Fatalf("assign role: %v status %d", err, resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	// list users
+	req, _ = http.NewRequest(http.MethodGet, srv.URL+"/user/list?tenantID=default", nil)
+	req.Header.Set("Authorization", "Bearer "+adminTok)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		t.Fatalf("list users: %v status %d", err, resp.StatusCode)
+	}
+	var list []user.User
+	if err := json.NewDecoder(resp.Body).Decode(&list); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	resp.Body.Close()
+	if len(list) != 2 { // admin and bob
+		t.Fatalf("expected 2 users, got %d", len(list))
+	}
+
+	// get user bob
+	req, _ = http.NewRequest(http.MethodGet, srv.URL+"/user/get?tenantID=default&username=bob", nil)
+	req.Header.Set("Authorization", "Bearer "+adminTok)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		t.Fatalf("get user: %v status %d", err, resp.StatusCode)
+	}
+	var u user.User
+	if err := json.NewDecoder(resp.Body).Decode(&u); err != nil {
+		t.Fatalf("decode user: %v", err)
+	}
+	resp.Body.Close()
+	if u.Username != "bob" || len(u.Roles) != 1 || u.Roles[0] != "editor" {
+		t.Fatalf("unexpected user %+v", u)
+	}
+
+	// unauthorized with bob token
+	bobTok := tokenFor(t, "bob")
+	req, _ = http.NewRequest(http.MethodPost, srv.URL+"/user/delete", strings.NewReader(`{"tenantID":"default","username":"bob"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+bobTok)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("bob delete request: %v", err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected forbidden, got %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	// delete bob as admin
+	req, _ = http.NewRequest(http.MethodPost, srv.URL+"/user/delete", strings.NewReader(`{"tenantID":"default","username":"bob"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+adminTok)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		t.Fatalf("delete user: %v status %d", err, resp.StatusCode)
+	}
+	resp.Body.Close()
+}


### PR DESCRIPTION
## Summary
- add in-memory user store with optional YAML persistence
- expose CRUD endpoints for users with role-based authorization
- document API and update Postman collection

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6893a2f3eb30832c81bac68f9e9e1c96