### PR TITLE
docs: add local end-to-end testing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Load the sample policy:
 
 ```sh
 cp examples/rbac.yaml configs/policies.yaml
-curl -X POST http://localhost:8080/reload -d '{"tenantID":"acme"}'
+curl -X POST http://localhost:8080/reload -d '{"tenantID":"default"}'
 ```
 
 Expected:
@@ -50,7 +50,7 @@ Check access:
 ```sh
 curl -s -X POST http://localhost:8080/check-access \
   -H 'Content-Type: application/json' \
-  -d '{"tenantID":"acme","subject":"alice","resource":"file1","action":"read"}'
+  -d '{"tenantID":"default","subject":"alice","resource":"file1","action":"read"}'
 ```
 
 Expected response:
@@ -124,12 +124,13 @@ Run a check:
 ```sh
 curl -s -X POST http://localhost:8080/check-access \
   -H 'Content-Type: application/json' \
-  -d '{"tenantID":"acme","subject":"alice","resource":"file1","action":"read"}'
+  -d '{"tenantID":"default","subject":"alice","resource":"file1","action":"read"}'
 ```
 
 ## Documentation
 
 - [Quickstart](docs/quickstart.md)
+- [Local End-to-End Testing](docs/local-testing.md)
 - [Tenants](docs/tenants.md)
 - [Policies](docs/policies.md)
 - [Graph](docs/graph.md)
@@ -155,14 +156,14 @@ Create a user:
 curl -X POST http://localhost:8080/user/create \
   -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer <token>' \
-  -d '{"tenantID":"acme","username":"bob"}'
+  -d '{"tenantID":"default","username":"bob"}'
 ```
 
 List users:
 
 ```sh
 curl -H 'Authorization: Bearer <token>' \
-  'http://localhost:8080/user/list?tenantID=acme'
+  'http://localhost:8080/user/list?tenantID=default'
 ```
 
 Additional endpoints support assigning roles, deleting users and fetching a single user. See [docs/users.md](docs/users.md) for details.

--- a/docs/local-testing.md
+++ b/docs/local-testing.md
@@ -1,0 +1,106 @@
+# Local End-to-End Testing
+
+The following steps walk through a complete flow of running the service, creating users, obtaining tokens, and verifying policy decisions. The service ships with a default tenant named `default`. For local testing we seed it with demo users copied from the `acme` example.
+
+## 1. Start the stack
+
+```sh
+cp .env.example .env
+# adjust values as needed
+cp examples/rbac.yaml configs/policies.yaml
+mkdir -p configs/default
+cp configs/acme/users.yaml configs/default/users.yaml
+
+# build and launch the authorization service and Keycloak
+ docker compose up --build
+```
+
+## 2. Reload the policy
+
+In another terminal once the service is running:
+
+```sh
+curl -X POST http://localhost:8080/reload -d '{"tenantID":"default"}'
+```
+
+Expected:
+
+```text
+policies reloaded
+```
+
+## 3. Obtain an admin token
+
+Keycloak exposes demo users. Retrieve a token for `alice` (TenantAdmin) using the password grant:
+
+```sh
+curl -s -X POST \
+  http://localhost:8081/realms/authz-service/protocol/openid-connect/token \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d 'grant_type=password&client_id=authz-client&username=alice&password=alice'
+```
+
+Save the returned `access_token` in an environment variable for later use:
+
+```sh
+TOKEN=$(curl -s -X POST \
+  http://localhost:8081/realms/authz-service/protocol/openid-connect/token \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d 'grant_type=password&client_id=authz-client&username=alice&password=alice' | jq -r .access_token)
+```
+
+## 4. Create a new user in the service
+
+Use the admin token to register a user `charlie` in tenant `default` with the `admin` role defined in the sample policy:
+
+```sh
+curl -X POST http://localhost:8080/user/create \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"tenantID":"default","username":"charlie","roles":["admin"]}'
+```
+
+The service persists users under `configs/default/users.yaml` when started with `--persist-users` (enabled in `docker-compose.yml`).
+
+## 5. Add the user to Keycloak
+
+Open [http://localhost:8081](http://localhost:8081) and log in with `admin`/`admin`. Create a user `charlie`, set a password, and assign the realm role `admin` so that issued tokens contain the matching `roles` claim.
+
+## 6. Obtain a token for the new user
+
+Request a token using `charlie`'s credentials:
+
+```sh
+CHARLIE_TOKEN=$(curl -s -X POST \
+  http://localhost:8081/realms/authz-service/protocol/openid-connect/token \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d 'grant_type=password&client_id=authz-client&username=charlie&password=charlie' | jq -r .access_token)
+```
+
+## 7. Verify policy decisions
+
+Check that `charlie` can read `file1` according to the sample policy:
+
+```sh
+curl -s -X POST http://localhost:8080/check-access \
+  -H 'Content-Type: application/json' \
+  -d '{"tenantID":"default","subject":"charlie","resource":"file1","action":"read"}'
+```
+
+Expected response:
+
+```json
+{"allow":true}
+```
+
+Access checks do not require an authentication header, but other management endpoints do. Use the `Authorization: Bearer $CHARLIE_TOKEN` header with APIs that require authentication.
+
+## 8. Clean up
+
+Stop the services when finished:
+
+```sh
+docker compose down -v
+```
+
+This sequence demonstrates creating a user, acquiring tokens, and verifying policies in a local environment.

--- a/examples/rbac.yaml
+++ b/examples/rbac.yaml
@@ -10,8 +10,8 @@ policies:
     description: Admins can read any file
     subjects:
       - role: admin
-    resources:
+    resource:
       - "*"
-    actions:
+    action:
       - read
     effect: allow


### PR DESCRIPTION
## Summary
- document full local testing flow from startup to policy checks
- link local testing guide from README
- align RBAC example policy with validator schema
- clarify default tenant usage in README and local testing guide

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6893c94a30f4832c8527535ee0f91668