### PR TITLE
fix: use WithEndpointURL for OTLP traces exporter

### DIFF
--- a/internal/telemetry/trace.go
+++ b/internal/telemetry/trace.go
@@ -20,7 +20,7 @@ func InitTracer(ctx context.Context) (func(context.Context) error, error) {
 	}
 
 	exporter, err := otlptracehttp.New(ctx,
-		otlptracehttp.WithEndpoint(endpoint),
+		otlptracehttp.WithEndpointURL(endpoint),
 		otlptracehttp.WithInsecure(),
 	)
 	if err != nil {


### PR DESCRIPTION
## Summary
- fix OTLP trace exporter endpoint handling

## Testing
- `go test ./...` *(interrupted: no output after waiting)*

------
https://chatgpt.com/codex/tasks/task_e_6894e49cb1fc832c8f03ab8190c78d48