### PR TITLE
Epic A: OIDC IdentityProvider (JWT verify, claim mapping, JWKS cache)

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1,0 +1,37 @@
+# Configuration
+
+A sample configuration lives in `configs/default/config.yaml`:
+
+```yaml
+identity:
+  issuer: "https://idp.example.com/realms/main"
+  jwks_url: "https://idp.example.com/realms/main/protocol/openid-connect/certs"
+  audience: "authorization-service"
+  claims:
+    subject: "sub"
+    username: "preferred_username"
+    tenant: "tenant"
+    roles:
+      - "realm_access.roles"
+      - "resource_access.authorization-service.roles"
+    strip_prefix: ""
+server:
+  addr: ":8080"
+  log_level: "info"
+```
+
+## Fields
+
+| Path                                   | Type     | Default | Description                                      |
+|----------------------------------------|----------|---------|--------------------------------------------------|
+| `identity.issuer`                      | string   | —       | Expected `iss` claim.                            |
+| `identity.jwks_url`                    | string   | —       | JWKS endpoint for verifying tokens.             |
+| `identity.audience`                    | string   | —       | Expected `aud` claim.                            |
+| `identity.claims.subject`              | string   | `sub`   | Claim path for the subject identifier.          |
+| `identity.claims.username`             | string   | `preferred_username` | Claim path for the username.          |
+| `identity.claims.tenant`               | string   | `tenant`| Claim path for the tenant (optional).           |
+| `identity.claims.roles`                | []string | shown   | Claim paths evaluated for roles.                |
+| `identity.claims.strip_prefix`         | string   | ``      | Prefix removed from roles before normalization. |
+| `server.addr`                          | string   | `:8080` | Listen address.                                  |
+| `server.log_level`                     | string   | `info`  | Log level.                                       |
+

--- a/README.md
+++ b/README.md
@@ -26,6 +26,26 @@ OIDC_AUDIENCES=authorization-service
 OIDC_TENANT_CLAIM=tenantID
 ```
 
+Example configuration file (`configs/default/config.yaml`):
+
+```yaml
+identity:
+  issuer: "https://idp.example.com/realms/main"
+  jwks_url: "https://idp.example.com/realms/main/protocol/openid-connect/certs"
+  audience: "authorization-service"
+  claims:
+    subject: "sub"
+    username: "preferred_username"
+    tenant: "tenant"
+    roles:
+      - "realm_access.roles"
+      - "resource_access.authorization-service.roles"
+    strip_prefix: ""
+server:
+  addr: ":8080"
+  log_level: "info"
+```
+
 Tokens are verified against the issuer's JWKS and must include `sub`, `aud`, `exp` and the `tenantID` claim (or the name specified by `OIDC_TENANT_CLAIM`). A typical payload looks like:
 
 ```json

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,3 +10,12 @@ We will investigate and respond as quickly as possible. Please do not publicly d
 
 Security fixes are applied to the latest main branch. Please upgrade to the newest release to ensure you have the latest patches.
 
+## Token Verification
+
+The service validates all JWTs against the following rules:
+
+- `iss` and `aud` must match configured values.
+- `exp` and `nbf` are enforced with a ±60s clock skew tolerance.
+- Signing keys are loaded from the issuer's JWKS endpoint, cached by `kid`, and refreshed in the background with jitter to avoid thundering herds.
+- Tokens or claims are never logged.
+

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,9 @@
+# Testing
+
+Run unit tests:
+
+```sh
+make test
+```
+
+To test locally against a custom JWKS, start an HTTP server that serves a `jwks.json` file and point `identity.jwks_url` to it in the configuration.

--- a/configs/default/config.yaml
+++ b/configs/default/config.yaml
@@ -1,0 +1,15 @@
+identity:
+  issuer: "https://idp.example.com/realms/main"
+  jwks_url: "https://idp.example.com/realms/main/protocol/openid-connect/certs"
+  audience: "authorization-service"
+  claims:
+    subject: "sub"
+    username: "preferred_username"
+    tenant: "tenant"
+    roles:
+      - "realm_access.roles"
+      - "resource_access.authorization-service.roles"
+    strip_prefix: ""
+server:
+  addr: ":8080"
+  log_level: "info"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,3 +53,18 @@ The API exposes Prometheus metrics on `/metrics` and traces via OpenTelemetry.
 
 ## Notes & Caveats
 This high-level diagram omits internal caches and background workers for brevity.
+
+## Identity Provider Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant API
+    participant IdP
+    Client->>API: Bearer JWT
+    API->>IdP: Fetch JWKS (cached)
+    IdP-->>API: Signing keys
+    API->>API: Verify iss/aud/exp/nbf
+    API->>API: Map claims to principal
+    API-->>Client: Authorized decision
+```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config represents the application configuration.
+type Config struct {
+	Identity IdentityConfig `yaml:"identity"`
+	Server   ServerConfig   `yaml:"server"`
+}
+
+// IdentityConfig defines OIDC related settings.
+type IdentityConfig struct {
+	Issuer   string       `yaml:"issuer"`
+	JWKSURL  string       `yaml:"jwks_url"`
+	Audience string       `yaml:"audience"`
+	Claims   ClaimsConfig `yaml:"claims"`
+}
+
+// ClaimsConfig maps claim paths to principal fields.
+type ClaimsConfig struct {
+	Subject     string   `yaml:"subject"`
+	Username    string   `yaml:"username"`
+	Tenant      string   `yaml:"tenant"`
+	Roles       []string `yaml:"roles"`
+	StripPrefix string   `yaml:"strip_prefix"`
+}
+
+// ServerConfig defines server settings.
+type ServerConfig struct {
+	Addr     string `yaml:"addr"`
+	LogLevel string `yaml:"log_level"`
+}
+
+// Load reads configuration from a YAML file.
+func Load(path string) (Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Config{}, err
+	}
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return Config{}, err
+	}
+	return cfg, nil
+}

--- a/internal/identity/oidc.go
+++ b/internal/identity/oidc.go
@@ -1,0 +1,157 @@
+package identity
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+
+	"github.com/bradtumy/authorization-service/internal/config"
+	"github.com/bradtumy/authorization-service/internal/security"
+)
+
+// OIDCProvider implements IdentityProvider using OIDC JWTs.
+type OIDCProvider struct {
+	cfg  config.IdentityConfig
+	jwks *security.JWKSCache
+}
+
+// NewOIDCProvider creates a provider with JWKS caching.
+func NewOIDCProvider(ctx context.Context, cfg config.IdentityConfig) (*OIDCProvider, error) {
+	cache, err := security.NewJWKSCache(ctx, cfg.JWKSURL, 5*time.Minute)
+	if err != nil {
+		return nil, err
+	}
+	return &OIDCProvider{cfg: cfg, jwks: cache}, nil
+}
+
+// Verify validates the JWT and returns token metadata.
+func (p *OIDCProvider) Verify(ctx context.Context, raw string) (TokenInfo, error) {
+	keyFunc := func(token *jwt.Token) (interface{}, error) {
+		kid, _ := token.Header["kid"].(string)
+		if kid == "" {
+			return nil, ErrInvalidToken
+		}
+		key, err := p.jwks.Key(ctx, kid)
+		if errors.Is(err, security.ErrNotFound) {
+			return nil, ErrKeyNotFound
+		}
+		return key, err
+	}
+
+	var claims jwt.MapClaims
+	parser := &jwt.Parser{}
+	tok, err := parser.ParseWithClaims(raw, &claims, keyFunc)
+	if err != nil || !tok.Valid {
+		return TokenInfo{}, ErrInvalidToken
+	}
+	if !claims.VerifyIssuer(p.cfg.Issuer, true) {
+		return TokenInfo{}, ErrInvalidToken
+	}
+	if !claims.VerifyAudience(p.cfg.Audience, true) {
+		return TokenInfo{}, ErrInvalidToken
+	}
+	now := time.Now()
+	if !claims.VerifyExpiresAt(now.Add(time.Minute).Unix(), true) {
+		return TokenInfo{}, ErrInvalidToken
+	}
+	if !claims.VerifyNotBefore(now.Add(-time.Minute).Unix(), true) {
+		return TokenInfo{}, ErrInvalidToken
+	}
+	aud, _ := claims["aud"].(string)
+	iss, _ := claims["iss"].(string)
+
+	return TokenInfo{Raw: raw, Issuer: iss, Aud: aud, Claims: map[string]any(claims)}, nil
+}
+
+// PrincipalFromClaims maps the token claims to a Principal based on config.
+func (p *OIDCProvider) PrincipalFromClaims(ctx context.Context, ti TokenInfo) (Principal, error) {
+	subj, ok := claimString(ti.Claims, p.cfg.Claims.Subject)
+	if !ok || subj == "" {
+		return Principal{}, ErrClaimMapping
+	}
+	uname, ok := claimString(ti.Claims, p.cfg.Claims.Username)
+	if !ok || uname == "" {
+		return Principal{}, ErrClaimMapping
+	}
+	tenant, _ := claimString(ti.Claims, p.cfg.Claims.Tenant)
+
+	roleSet := make(map[string]struct{})
+	for _, path := range p.cfg.Claims.Roles {
+		val, ok := claimValue(ti.Claims, path)
+		if !ok {
+			continue
+		}
+		for _, r := range toStringSlice(val) {
+			r = strings.ToLower(strings.TrimSpace(r))
+			if sp := strings.ToLower(p.cfg.Claims.StripPrefix); sp != "" && strings.HasPrefix(r, sp) {
+				r = strings.TrimPrefix(r, sp)
+			}
+			if r == "" {
+				continue
+			}
+			roleSet[r] = struct{}{}
+		}
+	}
+	roles := make([]string, 0, len(roleSet))
+	for r := range roleSet {
+		roles = append(roles, r)
+	}
+	sort.Strings(roles)
+
+	return Principal{
+		Subject:  subj,
+		Username: uname,
+		Tenant:   tenant,
+		Roles:    roles,
+		Issuer:   ti.Issuer,
+		Attrs:    map[string]string{},
+	}, nil
+}
+
+func claimValue(m map[string]any, path string) (any, bool) {
+	cur := any(m)
+	for _, p := range strings.Split(path, ".") {
+		mp, ok := cur.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		cur, ok = mp[p]
+		if !ok {
+			return nil, false
+		}
+	}
+	return cur, true
+}
+
+func claimString(m map[string]any, path string) (string, bool) {
+	v, ok := claimValue(m, path)
+	if !ok {
+		return "", false
+	}
+	s, ok := v.(string)
+	return s, ok
+}
+
+func toStringSlice(v any) []string {
+	switch t := v.(type) {
+	case []string:
+		return t
+	case []any:
+		out := make([]string, 0, len(t))
+		for _, i := range t {
+			if s, ok := i.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		if s, ok := t.(string); ok {
+			return []string{s}
+		}
+	}
+	return nil
+}

--- a/internal/identity/oidc_test.go
+++ b/internal/identity/oidc_test.go
@@ -1,0 +1,195 @@
+package identity
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	jose "gopkg.in/go-jose/go-jose.v2"
+
+	"github.com/bradtumy/authorization-service/internal/config"
+)
+
+func genKey(t *testing.T, kid string) (*rsa.PrivateKey, jose.JSONWebKey) {
+	k, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	jwk := jose.JSONWebKey{Key: &k.PublicKey, KeyID: kid, Algorithm: "RS256"}
+	return k, jwk
+}
+
+func jwksJSON(keys ...jose.JSONWebKey) []byte {
+	set := jose.JSONWebKeySet{Keys: keys}
+	b, _ := json.Marshal(set)
+	return b
+}
+
+func tokenString(t *testing.T, key *rsa.PrivateKey, kid string, claims map[string]any) string {
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims(claims))
+	tok.Header["kid"] = kid
+	s, err := tok.SignedString(key)
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+	return s
+}
+
+func cloneClaims(src map[string]any) map[string]any {
+	dst := make(map[string]any, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+func setupProvider(t *testing.T, jwksData *string, issuer, audience string) *OIDCProvider {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(*jwksData))
+	}))
+	t.Cleanup(srv.Close)
+
+	cfg := config.IdentityConfig{
+		Issuer:   issuer,
+		JWKSURL:  srv.URL,
+		Audience: audience,
+		Claims: config.ClaimsConfig{
+			Subject:     "sub",
+			Username:    "preferred_username",
+			Tenant:      "tenant",
+			Roles:       []string{"realm_access.roles", "resource_access.authorization-service.roles"},
+			StripPrefix: "ROLE_",
+		},
+	}
+	p, err := NewOIDCProvider(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("new provider: %v", err)
+	}
+	return p
+}
+
+func TestOIDCVerify(t *testing.T) {
+	issuer := "https://issuer.example.com"
+	audience := "authorization-service"
+	key1, jwk1 := genKey(t, "k1")
+	jwks := string(jwksJSON(jwk1))
+	p := setupProvider(t, &jwks, issuer, audience)
+
+	base := map[string]any{
+		"iss":                issuer,
+		"aud":                audience,
+		"exp":                time.Now().Add(time.Hour).Unix(),
+		"nbf":                time.Now().Add(-time.Minute).Unix(),
+		"sub":                "alice",
+		"preferred_username": "alice",
+	}
+
+	tests := []struct {
+		name    string
+		mod     func(map[string]any)
+		wantErr bool
+	}{
+		{"valid", func(m map[string]any) {}, false},
+		{"wrong_iss", func(m map[string]any) { m["iss"] = "other" }, true},
+		{"wrong_aud", func(m map[string]any) { m["aud"] = "other" }, true},
+		{"expired", func(m map[string]any) { m["exp"] = time.Now().Add(-time.Hour).Unix() }, true},
+		{"nbf_future", func(m map[string]any) { m["nbf"] = time.Now().Add(time.Hour).Unix() }, true},
+	}
+
+	for _, tc := range tests {
+		claims := cloneClaims(base)
+		tc.mod(claims)
+		tok := tokenString(t, key1, "k1", claims)
+		_, err := p.Verify(context.Background(), tok)
+		if tc.wantErr && err == nil {
+			t.Fatalf("%s: expected error", tc.name)
+		}
+		if !tc.wantErr && err != nil {
+			t.Fatalf("%s: unexpected error %v", tc.name, err)
+		}
+	}
+}
+
+func TestOIDCUnknownKidAndRotation(t *testing.T) {
+	issuer := "https://issuer.example.com"
+	audience := "authorization-service"
+	key1, jwk1 := genKey(t, "k1")
+	key2, jwk2 := genKey(t, "k2")
+	jwks := string(jwksJSON(jwk1))
+	p := setupProvider(t, &jwks, issuer, audience)
+
+	claims := map[string]any{
+		"iss":                issuer,
+		"aud":                audience,
+		"exp":                time.Now().Add(time.Hour).Unix(),
+		"nbf":                time.Now().Add(-time.Minute).Unix(),
+		"sub":                "alice",
+		"preferred_username": "alice",
+	}
+
+	// token signed with key2 but JWKS only has key1
+	tok2 := tokenString(t, key2, "k2", claims)
+	if _, err := p.Verify(context.Background(), tok2); err == nil {
+		t.Fatalf("expected unknown kid error")
+	}
+
+	// rotate JWKS to key2
+	jwks = string(jwksJSON(jwk2))
+	if err := p.jwks.Refresh(context.Background()); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+	if _, err := p.Verify(context.Background(), tok2); err != nil {
+		t.Fatalf("verify after rotate: %v", err)
+	}
+
+	// old token with key1 should now fail
+	tok1 := tokenString(t, key1, "k1", claims)
+	if _, err := p.Verify(context.Background(), tok1); err == nil {
+		t.Fatalf("expected failure for old key")
+	}
+}
+
+func TestPrincipalFromClaimsRoles(t *testing.T) {
+	issuer := "https://issuer.example.com"
+	audience := "authorization-service"
+	key1, jwk1 := genKey(t, "k1")
+	jwks := string(jwksJSON(jwk1))
+	p := setupProvider(t, &jwks, issuer, audience)
+
+	claims := map[string]any{
+		"iss":                issuer,
+		"aud":                audience,
+		"exp":                time.Now().Add(time.Hour).Unix(),
+		"nbf":                time.Now().Add(-time.Minute).Unix(),
+		"sub":                "s1",
+		"preferred_username": "bob",
+		"tenant":             "t1",
+		"realm_access":       map[string]any{"roles": []any{"Admin", "ROLE_user"}},
+		"resource_access":    map[string]any{"authorization-service": map[string]any{"roles": []any{"ROLE_ADMIN", "user"}}},
+	}
+
+	tok := tokenString(t, key1, "k1", claims)
+	ti, err := p.Verify(context.Background(), tok)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	princ, err := p.PrincipalFromClaims(context.Background(), ti)
+	if err != nil {
+		t.Fatalf("principal: %v", err)
+	}
+	want := []string{"admin", "user"}
+	if len(princ.Roles) != len(want) {
+		t.Fatalf("expected %d roles got %v", len(want), princ.Roles)
+	}
+	for i, r := range want {
+		if princ.Roles[i] != r {
+			t.Fatalf("role %d = %s want %s", i, princ.Roles[i], r)
+		}
+	}
+}

--- a/internal/identity/types.go
+++ b/internal/identity/types.go
@@ -1,0 +1,43 @@
+package identity
+
+import "context"
+
+// Principal represents an authenticated entity.
+type Principal struct {
+	Subject  string
+	Username string
+	Tenant   string
+	Roles    []string
+	Issuer   string
+	Attrs    map[string]string
+}
+
+// TokenInfo holds metadata about a verified token.
+type TokenInfo struct {
+	Raw    string
+	Issuer string
+	Aud    string
+	Claims map[string]any
+}
+
+// IdentityProvider verifies tokens and extracts principals.
+type IdentityProvider interface {
+	// Verify validates the raw token and returns token information.
+	Verify(ctx context.Context, raw string) (TokenInfo, error)
+	// PrincipalFromClaims maps token claims to a Principal.
+	PrincipalFromClaims(ctx context.Context, ti TokenInfo) (Principal, error)
+}
+
+// AuthError represents an authentication/authorization error.
+type AuthError struct {
+	Code    string
+	Message string
+}
+
+func (e *AuthError) Error() string { return e.Message }
+
+var (
+	ErrInvalidToken = &AuthError{Code: "invalid_token", Message: "token validation failed"}
+	ErrClaimMapping = &AuthError{Code: "claim_mapping_error", Message: "required claim missing"}
+	ErrKeyNotFound  = &AuthError{Code: "key_not_found", Message: "signing key not found"}
+)

--- a/internal/security/jwks_cache.go
+++ b/internal/security/jwks_cache.go
@@ -1,0 +1,105 @@
+package security
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"math/rand"
+	"net/http"
+	"sync"
+	"time"
+
+	jose "gopkg.in/go-jose/go-jose.v2"
+)
+
+// ErrNotFound indicates the requested key ID was not present.
+var ErrNotFound = errors.New("jwks key not found")
+
+// JWKSCache caches keys from a JWKS endpoint and refreshes them periodically.
+type JWKSCache struct {
+	url      string
+	client   *http.Client
+	mu       sync.RWMutex
+	keys     map[string]any
+	interval time.Duration
+	rnd      *rand.Rand
+}
+
+// NewJWKSCache creates a cache and starts a background refresh loop.
+func NewJWKSCache(ctx context.Context, url string, interval time.Duration) (*JWKSCache, error) {
+	c := &JWKSCache{
+		url:      url,
+		client:   &http.Client{Timeout: 5 * time.Second},
+		keys:     make(map[string]any),
+		interval: interval,
+		rnd:      rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+	if err := c.Refresh(ctx); err != nil {
+		return nil, err
+	}
+	go c.loop(ctx)
+	return c, nil
+}
+
+func (c *JWKSCache) loop(ctx context.Context) {
+	for {
+		jitter := time.Duration(c.rnd.Int63n(int64(c.interval / 10)))
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(c.interval + jitter):
+			_ = c.Refresh(context.Background())
+		}
+	}
+}
+
+// Refresh fetches the latest JWKS from the remote URL.
+func (c *JWKSCache) Refresh(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	var set jose.JSONWebKeySet
+	if err := json.NewDecoder(resp.Body).Decode(&set); err != nil {
+		return err
+	}
+
+	m := make(map[string]any)
+	for _, k := range set.Keys {
+		if k.KeyID == "" || k.Key == nil {
+			continue
+		}
+		m[k.KeyID] = k.Key
+	}
+
+	c.mu.Lock()
+	c.keys = m
+	c.mu.Unlock()
+	return nil
+}
+
+// Key returns the public key for the given kid.
+func (c *JWKSCache) Key(ctx context.Context, kid string) (any, error) {
+	c.mu.RLock()
+	k, ok := c.keys[kid]
+	c.mu.RUnlock()
+	if ok {
+		return k, nil
+	}
+	if err := c.Refresh(ctx); err != nil {
+		return nil, err
+	}
+	c.mu.RLock()
+	k, ok = c.keys[kid]
+	c.mu.RUnlock()
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return k, nil
+}


### PR DESCRIPTION
## Summary
- add identity interfaces and OIDC provider with claim mapping
- implement JWKS cache with jittered refresh and config loader
- document configuration, security rules, and testing guidance

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689519aad5a8832caee228713c4465c4