### PR TITLE
Epic B: JWTAuth middleware + principal context helpers

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -7,3 +7,9 @@ make test
 ```
 
 To test locally against a custom JWKS, start an HTTP server that serves a `jwks.json` file and point `identity.jwks_url` to it in the configuration.
+
+For end-to-end tests or manual API calls, include a valid JWT in the `Authorization` header:
+
+```sh
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8080/healthz
+```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,8 +4,9 @@ The authorization service is composed of a small set of components that work tog
 
 ```mermaid
 graph TD
-    C[Client] -->|HTTP| API[HTTP API]
-    API -->|Validate JWT| OIDC[OIDC Provider]
+    C[Client] -->|HTTP| MW[JWTAuth Middleware]
+    MW -->|Verify JWT| IdP[Identity Provider]
+    MW -->|Principal ctx| API[HTTP API]
     API --> PolicyEngine
     PolicyEngine --> PolicyStore[(Policy Store)]
     PolicyEngine --> Graph[Relationship Graph]
@@ -14,7 +15,7 @@ graph TD
 ```
 
 * **HTTP API** – exposes endpoints for policy management and access checks.
-* **OIDC Middleware** – verifies JWTs against configured issuers.
+* **JWTAuth Middleware** – verifies JWTs via the configured identity provider and stores the principal on the request context.
 * **Policy Engine** – evaluates CDL policies using a graph of relationships.
 * **Policy Store** – caches policies for each tenant and persists them via pluggable backends (memory, SQLite, PostgreSQL).
 * **Telemetry** – exports Prometheus metrics and OpenTelemetry traces for observability.

--- a/internal/http/middleware/context.go
+++ b/internal/http/middleware/context.go
@@ -1,0 +1,17 @@
+package middleware
+
+import (
+	"context"
+
+	"github.com/bradtumy/authorization-service/internal/identity"
+)
+
+// principalKey is the context key used to store the authenticated principal.
+type principalKey struct{}
+
+// PrincipalFromContext retrieves the authenticated principal from ctx.
+// It returns false if no principal is present.
+func PrincipalFromContext(ctx context.Context) (*identity.Principal, bool) {
+	p, ok := ctx.Value(principalKey{}).(*identity.Principal)
+	return p, ok
+}

--- a/internal/http/middleware/jwt.go
+++ b/internal/http/middleware/jwt.go
@@ -1,0 +1,35 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/bradtumy/authorization-service/internal/identity"
+)
+
+// JWTAuth validates a bearer token using the provided IdentityProvider. On
+// successful verification the resulting principal is stored on the request
+// context and the next handler is invoked. Failure results in 401 Unauthorized.
+func JWTAuth(idp identity.IdentityProvider, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := strings.TrimSpace(r.Header.Get("Authorization"))
+		if !strings.HasPrefix(auth, "Bearer ") {
+			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+			return
+		}
+		raw := strings.TrimPrefix(auth, "Bearer ")
+		ti, err := idp.Verify(r.Context(), raw)
+		if err != nil {
+			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+			return
+		}
+		principal, err := idp.PrincipalFromClaims(r.Context(), ti)
+		if err != nil {
+			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+			return
+		}
+		ctx := context.WithValue(r.Context(), principalKey{}, &principal)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}

--- a/internal/http/middleware/jwt_test.go
+++ b/internal/http/middleware/jwt_test.go
@@ -1,0 +1,76 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/bradtumy/authorization-service/internal/identity"
+)
+
+type mockIDP struct {
+	verify    func(ctx context.Context, raw string) (identity.TokenInfo, error)
+	principal func(ctx context.Context, ti identity.TokenInfo) (identity.Principal, error)
+}
+
+func (m *mockIDP) Verify(ctx context.Context, raw string) (identity.TokenInfo, error) {
+	return m.verify(ctx, raw)
+}
+
+func (m *mockIDP) PrincipalFromClaims(ctx context.Context, ti identity.TokenInfo) (identity.Principal, error) {
+	return m.principal(ctx, ti)
+}
+
+func TestJWTAuth(t *testing.T) {
+	idp := &mockIDP{
+		verify: func(ctx context.Context, raw string) (identity.TokenInfo, error) {
+			if raw != "good" {
+				return identity.TokenInfo{}, identity.ErrInvalidToken
+			}
+			return identity.TokenInfo{Raw: raw, Claims: map[string]any{}}, nil
+		},
+		principal: func(ctx context.Context, ti identity.TokenInfo) (identity.Principal, error) {
+			return identity.Principal{Subject: "user"}, nil
+		},
+	}
+
+	final := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p, ok := PrincipalFromContext(r.Context())
+		if !ok || p.Subject != "user" {
+			t.Fatalf("principal missing from context")
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := func() http.Handler { return JWTAuth(idp, final) }
+
+	t.Run("missing token", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rr := httptest.NewRecorder()
+		handler().ServeHTTP(rr, req)
+		if rr.Code != http.StatusUnauthorized {
+			t.Fatalf("expected 401 got %d", rr.Code)
+		}
+	})
+
+	t.Run("invalid token", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("Authorization", "Bearer bad")
+		rr := httptest.NewRecorder()
+		handler().ServeHTTP(rr, req)
+		if rr.Code != http.StatusUnauthorized {
+			t.Fatalf("expected 401 got %d", rr.Code)
+		}
+	})
+
+	t.Run("valid token", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("Authorization", "Bearer good")
+		rr := httptest.NewRecorder()
+		handler().ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected 200 got %d", rr.Code)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- add JWTAuth middleware that verifies bearer tokens and stores the principal on the request context
- expose `PrincipalFromContext` helper
- document request flow and how to include tokens in e2e tests

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6895209a3fe4832c9430c39ffeeb3351