### PR TITLE
Epic C: RBAC Authorizer + file-backed PolicyStore (tenant-scoped)

### DIFF
--- a/POLICY.md
+++ b/POLICY.md
@@ -1,0 +1,44 @@
+# Policy Schema
+
+Policies are expressed in YAML and define role-to-permission mappings scoped by tenant.
+
+```yaml
+# configs/default/policy.yaml
+tenants:
+  default:
+    roles:
+      admin:
+        permissions:
+          - user:list
+          - user:create
+          - policy:read
+      viewer:
+        permissions:
+          - user:list
+```
+
+## Schema
+
+- `tenants` – map of tenant identifiers.
+- `roles` – map of role names within a tenant.
+- `permissions` – list of allowed actions for the role.
+
+Tenants without an explicit entry fall back to `default` only when the principal
+omits a tenant value. Unknown tenants or roles are denied by default.
+
+## Example
+
+```yaml
+tenants:
+  acme:
+    roles:
+      editor:
+        permissions:
+          - doc:write
+  default:
+    roles:
+      viewer:
+        permissions:
+          - user:list
+```
+

--- a/README.md
+++ b/README.md
@@ -68,6 +68,28 @@ Start the service:
 docker compose up --build
 ```
 
+### RBAC Quickstart
+
+Define tenant‑scoped roles and permissions in `configs/default/policy.yaml`:
+
+```yaml
+tenants:
+  default:
+    roles:
+      admin:
+        permissions: ["user:list","user:create","policy:read"]
+      viewer:
+        permissions: ["user:list"]
+```
+
+Load the policy and check access in Go:
+
+```go
+store, _ := policy.NewFileStore("configs/default/policy.yaml")
+authz := authz.NewRBAC(store, time.Minute)
+allowed, _ := authz.IsAllowed(ctx, principal, policy.Permission("user:list"), nil)
+```
+
 Load the sample policy:
 
 ```sh

--- a/configs/default/policy.yaml
+++ b/configs/default/policy.yaml
@@ -1,0 +1,11 @@
+tenants:
+  default:
+    roles:
+      admin:
+        permissions:
+          - user:list
+          - user:create
+          - policy:read
+      viewer:
+        permissions:
+          - user:list

--- a/internal/authz/authorizer.go
+++ b/internal/authz/authorizer.go
@@ -1,0 +1,15 @@
+package authz
+
+import (
+	"context"
+
+	"github.com/bradtumy/authorization-service/internal/identity"
+	"github.com/bradtumy/authorization-service/internal/policy"
+)
+
+// Authorizer checks permissions for principals.
+type Authorizer interface {
+	// IsAllowed returns true if the principal has the permission on the resource.
+	// Default deny: absence of matching permission yields false with nil error.
+	IsAllowed(ctx context.Context, p identity.Principal, perm policy.Permission, resource map[string]string) (bool, error)
+}

--- a/internal/authz/rbac.go
+++ b/internal/authz/rbac.go
@@ -1,0 +1,83 @@
+package authz
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/bradtumy/authorization-service/internal/identity"
+	"github.com/bradtumy/authorization-service/internal/policy"
+)
+
+// RBAC implements role-based access control Authorizer.
+type RBAC struct {
+	store policy.PolicyStore
+	ttl   time.Duration
+
+	mu    sync.Mutex
+	cache map[string]cacheEntry
+}
+
+type cacheEntry struct {
+	perms   map[policy.Permission]struct{}
+	expires time.Time
+}
+
+// NewRBAC creates a new RBAC authorizer with the given PolicyStore and cache TTL.
+func NewRBAC(store policy.PolicyStore, ttl time.Duration) *RBAC {
+	if ttl <= 0 {
+		ttl = time.Minute
+	}
+	return &RBAC{store: store, ttl: ttl, cache: make(map[string]cacheEntry)}
+}
+
+// IsAllowed checks if the principal has the given permission.
+// Resources are currently ignored but accepted for future ABAC extensions.
+func (r *RBAC) IsAllowed(ctx context.Context, p identity.Principal, perm policy.Permission, resource map[string]string) (bool, error) {
+	tenant := p.Tenant
+	if tenant == "" {
+		tenant = "default"
+	}
+	if len(p.Roles) == 0 {
+		return false, nil
+	}
+	roles := append([]string(nil), p.Roles...)
+	sort.Strings(roles)
+	h := sha256.Sum256([]byte(strings.Join(roles, ",")))
+	key := tenant + ":" + hex.EncodeToString(h[:])
+
+	r.mu.Lock()
+	ce, ok := r.cache[key]
+	if ok && time.Now().Before(ce.expires) {
+		_, allowed := ce.perms[perm]
+		r.mu.Unlock()
+		return allowed, nil
+	}
+	r.mu.Unlock()
+
+	perms := make(map[policy.Permission]struct{})
+	for _, role := range roles {
+		ps, err := r.store.RolePermissions(ctx, tenant, role)
+		if err != nil {
+			if errors.Is(err, policy.ErrNotFound) {
+				continue
+			}
+			return false, err
+		}
+		for _, p := range ps {
+			perms[p] = struct{}{}
+		}
+	}
+	r.mu.Lock()
+	r.cache[key] = cacheEntry{perms: perms, expires: time.Now().Add(r.ttl)}
+	_, allowed := perms[perm]
+	r.mu.Unlock()
+	return allowed, nil
+}
+
+var _ Authorizer = (*RBAC)(nil)

--- a/internal/authz/rbac_test.go
+++ b/internal/authz/rbac_test.go
@@ -1,0 +1,119 @@
+package authz
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/bradtumy/authorization-service/internal/identity"
+	"github.com/bradtumy/authorization-service/internal/policy"
+)
+
+func writePolicy(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "policy.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+	return path
+}
+
+const testPolicy = `tenants:
+  default:
+    roles:
+      admin:
+        permissions: ["user:list","user:create","policy:read"]
+      viewer:
+        permissions: ["user:list"]
+  acme:
+    roles:
+      admin:
+        permissions: ["user:list"]
+`
+
+func newAuthorizer(t *testing.T) Authorizer {
+	path := writePolicy(t, testPolicy)
+	store, err := policy.NewFileStore(path)
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	return NewRBAC(store, time.Minute)
+}
+
+func TestAdminViewer(t *testing.T) {
+	a := newAuthorizer(t)
+	ctx := context.Background()
+
+	admin := identity.Principal{Roles: []string{"admin"}}
+	ok, err := a.IsAllowed(ctx, admin, policy.Permission("user:create"), nil)
+	if err != nil || !ok {
+		t.Fatalf("admin should allow create: ok=%v err=%v", ok, err)
+	}
+
+	viewer := identity.Principal{Roles: []string{"viewer"}}
+	ok, err = a.IsAllowed(ctx, viewer, policy.Permission("user:create"), nil)
+	if err != nil {
+		t.Fatalf("viewer error: %v", err)
+	}
+	if ok {
+		t.Fatalf("viewer should deny create")
+	}
+}
+
+func TestMultipleRoles(t *testing.T) {
+	a := newAuthorizer(t)
+	ctx := context.Background()
+	p := identity.Principal{Roles: []string{"viewer", "admin"}}
+	ok, err := a.IsAllowed(ctx, p, policy.Permission("policy:read"), nil)
+	if err != nil || !ok {
+		t.Fatalf("expected allow with multiple roles: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestTenantScoping(t *testing.T) {
+	a := newAuthorizer(t)
+	ctx := context.Background()
+
+	// default tenant
+	p := identity.Principal{Roles: []string{"admin"}}
+	ok, err := a.IsAllowed(ctx, p, policy.Permission("user:create"), nil)
+	if err != nil || !ok {
+		t.Fatalf("default tenant admin should allow create")
+	}
+
+	// named tenant
+	p = identity.Principal{Tenant: "acme", Roles: []string{"admin"}}
+	ok, err = a.IsAllowed(ctx, p, policy.Permission("user:create"), nil)
+	if err != nil {
+		t.Fatalf("named tenant error: %v", err)
+	}
+	if ok {
+		t.Fatalf("acme admin should deny create")
+	}
+}
+
+func TestUnknownRoleTenant(t *testing.T) {
+	a := newAuthorizer(t)
+	ctx := context.Background()
+
+	p := identity.Principal{Roles: []string{"bogus"}}
+	ok, err := a.IsAllowed(ctx, p, policy.Permission("user:list"), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatalf("unknown role should deny")
+	}
+
+	p = identity.Principal{Tenant: "unknown", Roles: []string{"admin"}}
+	ok, err = a.IsAllowed(ctx, p, policy.Permission("user:list"), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatalf("unknown tenant should deny")
+	}
+}

--- a/internal/policy/file_store.go
+++ b/internal/policy/file_store.go
@@ -1,0 +1,89 @@
+package policy
+
+import (
+	"context"
+	"os"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+// FileStore loads policy definitions from a YAML file.
+type FileStore struct {
+	mu       sync.RWMutex
+	policies map[string]map[string][]Permission // tenant -> role -> perms
+}
+
+// NewFileStore reads the policy file from path.
+func NewFileStore(path string) (*FileStore, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var cfg struct {
+		Tenants map[string]struct {
+			Roles map[string]struct {
+				Permissions []Permission `yaml:"permissions"`
+			} `yaml:"roles"`
+		} `yaml:"tenants"`
+	}
+	if err := yaml.Unmarshal(b, &cfg); err != nil {
+		return nil, err
+	}
+	policies := make(map[string]map[string][]Permission)
+	for t, td := range cfg.Tenants {
+		roles := make(map[string][]Permission)
+		for r, rd := range td.Roles {
+			roles[r] = append([]Permission(nil), rd.Permissions...)
+		}
+		policies[t] = roles
+	}
+	return &FileStore{policies: policies}, nil
+}
+
+// RolePermissions returns permissions for the given tenant and role.
+func (s *FileStore) RolePermissions(ctx context.Context, tenant, role string) ([]Permission, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	t, ok := s.policies[tenant]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	perms, ok := t[role]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return append([]Permission(nil), perms...), nil
+}
+
+// Refresh reloads the policy file from path.
+func (s *FileStore) Refresh(path string) error {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	var cfg struct {
+		Tenants map[string]struct {
+			Roles map[string]struct {
+				Permissions []Permission `yaml:"permissions"`
+			} `yaml:"roles"`
+		} `yaml:"tenants"`
+	}
+	if err := yaml.Unmarshal(b, &cfg); err != nil {
+		return err
+	}
+	policies := make(map[string]map[string][]Permission)
+	for t, td := range cfg.Tenants {
+		roles := make(map[string][]Permission)
+		for r, rd := range td.Roles {
+			roles[r] = append([]Permission(nil), rd.Permissions...)
+		}
+		policies[t] = roles
+	}
+	s.mu.Lock()
+	s.policies = policies
+	s.mu.Unlock()
+	return nil
+}
+
+var _ PolicyStore = (*FileStore)(nil)

--- a/internal/policy/store.go
+++ b/internal/policy/store.go
@@ -1,0 +1,19 @@
+package policy
+
+import (
+	"context"
+	"errors"
+)
+
+// Permission represents an allowed action.
+type Permission string
+
+// PolicyStore provides permission lookups for roles within a tenant.
+type PolicyStore interface {
+	// RolePermissions returns permissions for the given tenant and role.
+	// It returns ErrNotFound if the tenant or role does not exist.
+	RolePermissions(ctx context.Context, tenant, role string) ([]Permission, error)
+}
+
+// ErrNotFound is returned when a tenant or role does not exist.
+var ErrNotFound = errors.New("policy not found")


### PR DESCRIPTION
## Summary
- add RBAC Authorizer with short-lived cache
- provide file-backed policy store and default YAML schema
- document policy format and RBAC quickstart

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6895236129e4832ca60112d6808e85ae