### PR TITLE
feat: add VC-based authorization endpoint

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -1,0 +1,24 @@
+# API Reference
+
+## POST /authorize
+
+Evaluate an authorization decision using a Verifiable Credential and request context.
+
+### Request Body
+
+```json
+{
+  "credential": { /* Verifiable Credential */ },
+  "context": {
+    "action": "read",
+    "resource": "document:123",
+    "environment": {
+      "tenantID": "default"
+    }
+  }
+}
+```
+
+### Response
+
+Returns an authorization decision from the policy engine.

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1,0 +1,9 @@
+# Examples
+
+Sample Verifiable Credential and context files are available in the `examples` directory.
+
+```bash
+curl -X POST http://localhost:8080/authorize \
+  -H 'Content-Type: application/json' \
+  -d @<(jq -s '{credential:.[0], context:.[1]}' examples/vc.json examples/context.json)
+```

--- a/examples/context.json
+++ b/examples/context.json
@@ -1,0 +1,8 @@
+{
+  "action": "read",
+  "resource": "document:123",
+  "environment": {
+    "tenantID": "default",
+    "ip": "192.0.2.1"
+  }
+}

--- a/examples/vc.json
+++ b/examples/vc.json
@@ -1,0 +1,11 @@
+{
+  "@context": ["https://www.w3.org/2018/credentials/v1"],
+  "id": "https://example.org/credentials/3732",
+  "type": ["VerifiableCredential"],
+  "issuer": "https://example.org/issuers/14",
+  "issuanceDate": "2023-01-01T19:23:24Z",
+  "credentialSubject": {
+    "id": "did:example:123",
+    "name": "Alice"
+  }
+}


### PR DESCRIPTION
## Summary
- add `/authorize` endpoint that accepts W3C Verifiable Credentials and request context
- document authorize endpoint and provide sample credential/context files

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68953e9defd0832ca82a99eb74554eb0