### PR TITLE
feat: add VC-based policy evaluator

### DIFF
--- a/POLICY_LANGUAGE.md
+++ b/POLICY_LANGUAGE.md
@@ -1,0 +1,31 @@
+# Policy Language
+
+Policies are written in YAML and loaded from `./policies/*.yaml`. Each file contains a list of rules.
+
+## Rule Fields
+
+- `id` – unique identifier for the rule.
+- `effect` – `allow` or `deny`.
+- `roles` – list of required roles (RBAC).
+- `actions` – operations the rule applies to. `*` matches any action.
+- `resources` – protected resources. `*` matches any resource.
+- `conditions` – key/value attributes evaluated against VC and environment facts (ABAC).
+- `advice` – optional message returned when a deny rule matches.
+
+## Example
+
+```yaml
+- id: admin-read
+  effect: allow
+  roles: ["admin"]
+  actions: ["read"]
+  resources: ["*"]
+
+- id: sales-view
+  effect: allow
+  actions: ["view"]
+  resources: ["report"]
+  conditions:
+    department: sales
+```
+

--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -1,0 +1,140 @@
+package evaluator
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Rule defines a single authorization rule loaded from YAML.
+type Rule struct {
+	ID          string            `yaml:"id"`
+	Description string            `yaml:"description,omitempty"`
+	Roles       []string          `yaml:"roles,omitempty"`
+	Actions     []string          `yaml:"actions"`
+	Resources   []string          `yaml:"resources"`
+	Conditions  map[string]string `yaml:"conditions,omitempty"`
+	Effect      string            `yaml:"effect"` // "allow" or "deny"
+	Advice      string            `yaml:"advice,omitempty"`
+}
+
+// Evaluator loads policies and evaluates verifiable credentials against them.
+type Evaluator struct {
+	rules []Rule
+}
+
+// New reads all YAML policy files from dir and constructs an Evaluator.
+func New(dir string) (*Evaluator, error) {
+	files, err := filepath.Glob(filepath.Join(dir, "*.yaml"))
+	if err != nil {
+		return nil, err
+	}
+	var rules []Rule
+	for _, f := range files {
+		b, err := os.ReadFile(f)
+		if err != nil {
+			return nil, err
+		}
+		var rs []Rule
+		if err := yaml.Unmarshal(b, &rs); err != nil {
+			return nil, err
+		}
+		rules = append(rules, rs...)
+	}
+	return &Evaluator{rules: rules}, nil
+}
+
+// Context provides fields used during evaluation.
+type Context struct {
+	Action      string
+	Resource    string
+	Environment map[string]string
+}
+
+// Result is returned from Evaluate.
+type Result struct {
+	Allowed bool
+	Advice  string
+}
+
+// Evaluate returns the decision for the given VC and context.
+func (e *Evaluator) Evaluate(vc map[string]any, ctx Context) Result {
+	roles, attrs := extractFacts(vc)
+	facts := map[string]string{}
+	for k, v := range attrs {
+		facts[k] = v
+	}
+	for k, v := range ctx.Environment {
+		facts[k] = v
+	}
+	for _, r := range e.rules {
+		if !match(r.Actions, ctx.Action) || !match(r.Resources, ctx.Resource) {
+			continue
+		}
+		if len(r.Roles) > 0 && !hasAny(r.Roles, roles) {
+			continue
+		}
+		if len(r.Conditions) > 0 && !conditionsMatch(r.Conditions, facts) {
+			continue
+		}
+		if r.Effect == "allow" {
+			return Result{Allowed: true}
+		}
+		return Result{Allowed: false, Advice: r.Advice}
+	}
+	return Result{Allowed: false}
+}
+
+func match(list []string, v string) bool {
+	for _, item := range list {
+		if item == "*" || item == v {
+			return true
+		}
+	}
+	return false
+}
+
+func hasAny(req, have []string) bool {
+	set := make(map[string]struct{}, len(have))
+	for _, r := range have {
+		set[r] = struct{}{}
+	}
+	for _, r := range req {
+		if _, ok := set[r]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func conditionsMatch(conds, facts map[string]string) bool {
+	for k, v := range conds {
+		if facts[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// extractFacts retrieves roles and attributes from a VC-like structure.
+func extractFacts(vc map[string]any) ([]string, map[string]string) {
+	cs, _ := vc["credentialSubject"].(map[string]any)
+	var roles []string
+	attrs := map[string]string{}
+	if cs != nil {
+		if r, ok := cs["roles"].([]any); ok {
+			for _, v := range r {
+				roles = append(roles, fmt.Sprint(v))
+			}
+		}
+		for k, v := range cs {
+			if k == "roles" {
+				continue
+			}
+			attrs[k] = fmt.Sprint(v)
+		}
+	}
+	return roles, attrs
+}

--- a/internal/evaluator/evaluator_test.go
+++ b/internal/evaluator/evaluator_test.go
@@ -1,0 +1,46 @@
+package evaluator
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func policyDir() string {
+	return filepath.Join("..", "..", "policies")
+}
+
+func TestRBACEvaluation(t *testing.T) {
+	e, err := New(policyDir())
+	if err != nil {
+		t.Fatalf("new evaluator: %v", err)
+	}
+	ctx := Context{Action: "read", Resource: "doc"}
+	vc := map[string]any{"credentialSubject": map[string]any{"roles": []any{"admin"}}}
+	res := e.Evaluate(vc, ctx)
+	if !res.Allowed {
+		t.Fatalf("expected allowed, got %+v", res)
+	}
+	vc = map[string]any{"credentialSubject": map[string]any{"roles": []any{"viewer"}}}
+	res = e.Evaluate(vc, ctx)
+	if res.Allowed || res.Advice != "admin role required" {
+		t.Fatalf("expected deny with advice, got %+v", res)
+	}
+}
+
+func TestABACEvaluation(t *testing.T) {
+	e, err := New(policyDir())
+	if err != nil {
+		t.Fatalf("new evaluator: %v", err)
+	}
+	ctx := Context{Action: "view", Resource: "report"}
+	vc := map[string]any{"credentialSubject": map[string]any{"department": "sales"}}
+	res := e.Evaluate(vc, ctx)
+	if !res.Allowed {
+		t.Fatalf("expected allowed, got %+v", res)
+	}
+	vc = map[string]any{"credentialSubject": map[string]any{"department": "engineering"}}
+	res = e.Evaluate(vc, ctx)
+	if res.Allowed || res.Advice != "sales department required" {
+		t.Fatalf("expected deny with advice, got %+v", res)
+	}
+}

--- a/policies/abac.yaml
+++ b/policies/abac.yaml
@@ -1,0 +1,12 @@
+- id: sales-view
+  effect: allow
+  actions: ["view"]
+  resources: ["report"]
+  conditions:
+    department: sales
+
+- id: sales-view-deny
+  effect: deny
+  actions: ["view"]
+  resources: ["report"]
+  advice: sales department required

--- a/policies/rbac.yaml
+++ b/policies/rbac.yaml
@@ -1,0 +1,11 @@
+- id: admin-read
+  effect: allow
+  roles: ["admin"]
+  actions: ["read"]
+  resources: ["*"]
+
+- id: admin-read-deny
+  effect: deny
+  actions: ["read"]
+  resources: ["*"]
+  advice: admin role required


### PR DESCRIPTION
## Summary
- add YAML-driven policy evaluator supporting RBAC and ABAC rules for VCs
- document policy language and provide sample RBAC and ABAC policies
- include tests ensuring advice is returned on denied requests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68954120894c832caf9078ea24e005db