### PR TITLE
Align SDK clients with API and add test coverage

### DIFF
--- a/sdk/AuthorizationSDK.js
+++ b/sdk/AuthorizationSDK.js
@@ -1,35 +1,73 @@
-const jwt = require("jsonwebtoken");
-require("dotenv").config();
+const http = require('http');
+const https = require('https');
+const { URL } = require('url');
 
 class AuthorizationSDK {
-  constructor() {
-    this.clientId = process.env.CLIENT_ID;
-    this.clientSecret = process.env.CLIENT_SECRET;
+  constructor(options = {}) {
+    const envBase = process.env.AUTHZ_ADDR || process.env.AUTHZCTL_ADDR || 'http://localhost:8080';
+    this.baseUrl = (options.baseUrl || envBase).replace(/\/?$/, '/');
+    this.token = options.token || process.env.AUTHZ_TOKEN || process.env.AUTHZCTL_TOKEN || '';
   }
 
-  generateToken() {
-    const payload = {
-      client_id: this.clientId,
-      // Add any other necessary claims
-    };
-
-    const token = jwt.sign(payload, this.clientSecret, { expiresIn: "1d" });
-    return token;
+  async checkAccess({ tenantID, subject, resource, action, conditions = {} }) {
+    return this.#postJson('check-access', { tenantID, subject, resource, action, conditions });
   }
 
-  async evaluatePolicy(tenantID, subject, resource, action, conditions) {
-    const token = this.generateToken();
+  async simulateAccess({ tenantID, subject, resource, action, context = {} }) {
+    return this.#postJson('simulate', { tenantID, subject, resource, action, context });
+  }
 
-    // Implement logic to send policy evaluation request
-    // Example: use axios or fetch to make an HTTP request to your authorization service
-    // Ensure to include the generated token in the request headers
-    // Example:
-    // const response = await axios.post('https://your-auth-service/check-access', { tenantID, subject, resource, action, conditions }, { headers: { Authorization: `Bearer ${token}` } });
+  async compileRule(tenantID, rule) {
+    const response = await this.#postJson('compile', { tenantID, rule }, false);
+    return response;
+  }
 
-    // For simplicity, this example just logs the request details
-    console.log(
-      `Policy Evaluation Request: Tenant=${tenantID}, Subject=${subject}, Resource=${resource}, Action=${action}, Conditions=${conditions}`,
-    );
+  async validatePolicy(tenantID, policy) {
+    const response = await this.#postJson('validate-policy', { tenantID, policy }, false);
+    return response;
+  }
+
+  async #postJson(path, payload, parseJson = true) {
+    const url = new URL(path.replace(/^\//, ''), this.baseUrl);
+    const body = JSON.stringify(payload ?? {});
+    const headers = { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) };
+    if (this.token) {
+      headers.Authorization = `Bearer ${this.token}`;
+    }
+
+    const isHttps = url.protocol === 'https:';
+    const client = isHttps ? https : http;
+
+    return new Promise((resolve, reject) => {
+      const req = client.request(
+        url,
+        { method: 'POST', headers },
+        (res) => {
+          const chunks = [];
+          res.on('data', (chunk) => chunks.push(chunk));
+          res.on('end', () => {
+            const responseText = Buffer.concat(chunks).toString('utf-8');
+            if (res.statusCode !== 200) {
+              reject(new Error(`unexpected status ${res.statusCode}: ${responseText}`));
+              return;
+            }
+            if (!parseJson) {
+              resolve(responseText);
+              return;
+            }
+            try {
+              resolve(JSON.parse(responseText));
+            } catch (err) {
+              reject(err);
+            }
+          });
+        }
+      );
+
+      req.on('error', reject);
+      req.write(body);
+      req.end();
+    });
   }
 }
 

--- a/sdk/AuthorizationSDK.test.js
+++ b/sdk/AuthorizationSDK.test.js
@@ -1,0 +1,63 @@
+const http = require('http');
+const test = require('node:test');
+const assert = require('node:assert');
+const { once } = require('events');
+const AuthorizationSDK = require('./AuthorizationSDK');
+
+const responses = {
+  '/check-access': { status: 200, body: JSON.stringify({ allow: true, policyID: 'p1', reason: 'ok' }) },
+  '/simulate': { status: 200, body: JSON.stringify({ allow: false, reason: 'simulated' }) },
+  '/compile': { status: 200, body: 'compiled policy' },
+  '/validate-policy': { status: 200, body: 'policy valid' },
+};
+
+const server = http.createServer((req, res) => {
+  const response = responses[req.url];
+  if (!response) {
+    res.writeHead(404).end();
+    return;
+  }
+  res.writeHead(response.status, { 'Content-Type': 'application/json' });
+  res.end(response.body);
+});
+
+let baseUrl;
+
+const ready = (async () => {
+  server.listen(0);
+  await once(server, 'listening');
+  const { port } = server.address();
+  baseUrl = `http://localhost:${port}`;
+})();
+
+test.before(async () => {
+  await ready;
+});
+
+test('checkAccess returns decision payload', async () => {
+  const sdk = new AuthorizationSDK({ baseUrl, token: 'abc' });
+  const decision = await sdk.checkAccess({ tenantID: 't', subject: 's', resource: 'r', action: 'a' });
+  assert.strictEqual(decision.allow, true);
+});
+
+test('simulateAccess returns simulated decision', async () => {
+  const sdk = new AuthorizationSDK({ baseUrl });
+  const decision = await sdk.simulateAccess({ tenantID: 't', subject: 's', resource: 'r', action: 'a', context: { k: 'v' } });
+  assert.strictEqual(decision.reason, 'simulated');
+});
+
+test('compileRule returns raw response', async () => {
+  const sdk = new AuthorizationSDK({ baseUrl });
+  const compiled = await sdk.compileRule('tenant', 'rule');
+  assert.strictEqual(compiled, 'compiled policy');
+});
+
+test('validatePolicy returns raw response', async () => {
+  const sdk = new AuthorizationSDK({ baseUrl });
+  const result = await sdk.validatePolicy('tenant', 'policy');
+  assert.strictEqual(result, 'policy valid');
+});
+
+test.after(() => {
+  server.close();
+});

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,115 +1,87 @@
-# Authorization SDK for Node.js
+# Authorization SDKs
 
-## Overview
+This directory contains lightweight SDK clients for the authorization service in Node.js, Go, and Python. All SDKs align with the API routes exposed by the service and mirror the behavior of the `authzctl` terminal utility (e.g., `/check-access`, `/simulate`, `/compile`, `/validate-policy`).
 
-This SDK provides a convenient way for Node.js applications to interact with an authorization service. It allows developers to generate authentication tokens and evaluate access policies based on predefined rules.
-
-## Features
-
-- **Token Generation**: Generate authentication tokens using client credentials.
-- **Policy Evaluation**: Evaluate access policies based on subject, resource, and action.
-
-## Installation
-
-To install the SDK, you can use npm:
-
-```bash
-npm install @yourorganization/authorization-sdk
-```
-
-## Usage
+## Node.js
 
 ### Configuration
 
-Before using the SDK, make sure to set up your environment variables. Create a `.env` file in your project root with the following variables:
+- `AUTHZ_ADDR`/`AUTHZCTL_ADDR` (optional): Base URL for the service. Defaults to `http://localhost:8080`.
+- `AUTHZ_TOKEN`/`AUTHZCTL_TOKEN` (optional): Bearer token to include on requests.
 
-```dotenv
-SDK_CLIENT_ID=your_client_id_here
-SDK_CLIENT_SECRET=your_client_secret_here
-```
-
-### Example
-
-Here’s how you can use the SDK in your Node.js application (`index.js`):
+### Usage
 
 ```javascript
-require('dotenv').config(); // Load environment variables from .env file
-const AuthorizationSDK = require('@yourorganization/authorization-sdk');
+const AuthorizationSDK = require('./AuthorizationSDK');
+const sdk = new AuthorizationSDK({ baseUrl: 'http://localhost:8080', token: 'my-token' });
 
-// Initialize SDK with client credentials
-const sdk = new AuthorizationSDK({
-  clientId: process.env.SDK_CLIENT_ID,
-  clientSecret: process.env.SDK_CLIENT_SECRET,
+const decision = await sdk.checkAccess({
+  tenantID: 't1',
+  subject: 'user',
+  resource: 'file',
+  action: 'read',
+  conditions: { ip: '127.0.0.1' },
 });
 
-// Example usage to evaluate policy
-async function evaluatePolicy() {
-  const subject = 'user2';
-  const resource = 'file2';
-  const action = 'read';
+const simulation = await sdk.simulateAccess({
+  tenantID: 't1',
+  subject: 'user',
+  resource: 'file',
+  action: 'read',
+  context: { environment: 'dev' },
+});
 
-  try {
-    // Generate token using SDK method
-    const token = await sdk.generateToken();
-
-    // Call SDK method to evaluate policy
-    const decision = await sdk.checkAccess(token, subject, resource, action);
-
-    console.log('Policy Evaluation Result:', decision);
-  } catch (error) {
-    console.error('Error:', error.message);
-  }
-}
-
-// Call the example function
-evaluatePolicy();
+const compiled = await sdk.compileRule('t1', 'allow subject where true');
+const validation = await sdk.validatePolicy('t1', 'policy: allow');
 ```
 
-### SDK Methods
+### Tests
 
-#### `generateToken()`
+Run `node --test sdk/AuthorizationSDK.test.js`.
 
-Generates an authentication token using client credentials.
+## Go
 
-```javascript
-async function generateToken() {
-  try {
-    const token = await sdk.generateToken();
-    console.log('Generated Token:', token);
-  } catch (error) {
-    console.error('Failed to generate token:', error.message);
-  }
-}
+```go
+client := sdk.NewClient("http://localhost:8080")
+
+// Check access
+result, err := client.CheckAccess(sdk.AccessRequest{
+    TenantID: "t1",
+    Subject:  "user",
+    Resource: "file",
+    Action:   "read",
+})
+
+// Simulate with explicit context
+simulation, err := client.SimulateAccess(sdk.SimulationRequest{
+    TenantID: "t1",
+    Subject:  "user",
+    Resource: "file",
+    Action:   "read",
+    Context:  map[string]string{"environment": "dev"},
+})
+
+// Compile and validate policies
+compiled, err := client.CompileRule("t1", "allow subject where true")
+err = client.ValidatePolicy("t1", "policy: allow")
 ```
 
-#### `checkAccess(token, subject, resource, action)`
+Run `go test ./sdk/go` to execute the Go SDK tests.
 
-Checks access based on the provided authentication token, subject, resource, and action.
+## Python
 
-```javascript
-async function checkAccess() {
-  const token = 'your_generated_token';
-  const subject = 'user1';
-  const resource = 'file1';
-  const action = 'read';
+```python
+from sdk.python.authorization import Client
 
-  try {
-    const decision = await sdk.checkAccess(token, subject, resource, action);
-    console.log('Access Decision:', decision);
-  } catch (error) {
-    console.error('Failed to check access:', error.message);
-  }
-}
+client = Client('http://localhost:8080', token='my-token')
+
+# Check and simulate
+client.check_access('t1', 'user', 'file', 'read', {'ip': '127.0.0.1'})
+client.simulate_access('t1', 'user', 'file', 'read', {'environment': 'dev'})
+
+# Compile and validate
+client.compile_rule('t1', 'allow subject where true')
+client.validate_policy('t1', 'policy: allow')
 ```
 
-## Contributing
-
-Contributions are welcome! If you find any issues or have suggestions for improvements, please open an issue or submit a pull request on GitHub.
-
-## License
-
-This SDK is licensed under the MIT License. See the LICENSE file for more details.
-
----
-
-Adjust the placeholders (`@yourorganization/authorization-sdk`) with your actual package name if you plan to publish it on npm. Ensure to provide clear and concise examples, detailed usage instructions, and guidelines for setting up and configuring the SDK in different environments.
+Run `python -m pytest sdk/python/test_authorization.py` to exercise the Python SDK.

--- a/sdk/__init__.py
+++ b/sdk/__init__.py
@@ -1,0 +1,1 @@
+"""SDK package marker for Python imports."""

--- a/sdk/go/sdk.go
+++ b/sdk/go/sdk.go
@@ -1,89 +1,115 @@
 package sdk
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"io"
-	"net/http"
+"bytes"
+"encoding/json"
+"fmt"
+"io"
+"net/http"
+"strings"
 )
 
 type Client struct {
-	BaseURL    string
-	HTTPClient *http.Client
+        BaseURL    string
+        HTTPClient *http.Client
 }
 
 func NewClient(baseURL string) *Client {
-	return &Client{BaseURL: baseURL, HTTPClient: &http.Client{}}
+        return &Client{BaseURL: baseURL, HTTPClient: &http.Client{}}
 }
 
 type AccessRequest struct {
-	TenantID   string            `json:"tenantID"`
-	Subject    string            `json:"subject"`
-	Resource   string            `json:"resource"`
-	Action     string            `json:"action"`
-	Conditions map[string]string `json:"conditions,omitempty"`
+        TenantID   string            `json:"tenantID"`
+        Subject    string            `json:"subject"`
+        Resource   string            `json:"resource"`
+        Action     string            `json:"action"`
+        Conditions map[string]string `json:"conditions,omitempty"`
+}
+
+type SimulationRequest struct {
+        TenantID string            `json:"tenantID"`
+        Subject  string            `json:"subject"`
+        Resource string            `json:"resource"`
+        Action   string            `json:"action"`
+        Context  map[string]string `json:"context"`
 }
 
 type Decision struct {
-	Allow       bool     `json:"allow"`
-	PolicyID    string   `json:"policyID"`
-	Reason      string   `json:"reason"`
-	Remediation []string `json:"remediation"`
+        Allow       bool     `json:"allow"`
+        PolicyID    string   `json:"policyID"`
+        Reason      string   `json:"reason"`
+        Remediation []string `json:"remediation"`
 }
 
 func (c *Client) post(path string, payload any) (*http.Response, error) {
-	b, err := json.Marshal(payload)
-	if err != nil {
-		return nil, err
-	}
-	url := fmt.Sprintf("%s%s", c.BaseURL, path)
-	return c.HTTPClient.Post(url, "application/json", bytes.NewReader(b))
+        b, err := json.Marshal(payload)
+        if err != nil {
+                return nil, err
+        }
+        url := fmt.Sprintf("%s/%s", strings.TrimRight(c.BaseURL, "/"), strings.TrimLeft(path, "/"))
+        return c.HTTPClient.Post(url, "application/json", bytes.NewReader(b))
 }
 
 func (c *Client) CheckAccess(req AccessRequest) (*Decision, error) {
-	resp, err := c.post("/check-access", req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
-	}
-	var dec Decision
-	if err := json.NewDecoder(resp.Body).Decode(&dec); err != nil {
-		return nil, err
-	}
-	return &dec, nil
+        resp, err := c.post("/check-access", req)
+        if err != nil {
+                return nil, err
+        }
+        defer resp.Body.Close()
+        if resp.StatusCode != http.StatusOK {
+                body, _ := io.ReadAll(resp.Body)
+                return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+        }
+        var dec Decision
+        if err := json.NewDecoder(resp.Body).Decode(&dec); err != nil {
+                return nil, err
+        }
+        return &dec, nil
+}
+
+func (c *Client) SimulateAccess(req SimulationRequest) (*Decision, error) {
+        resp, err := c.post("/simulate", req)
+        if err != nil {
+                return nil, err
+        }
+        defer resp.Body.Close()
+        if resp.StatusCode != http.StatusOK {
+                body, _ := io.ReadAll(resp.Body)
+                return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+        }
+        var dec Decision
+        if err := json.NewDecoder(resp.Body).Decode(&dec); err != nil {
+                return nil, err
+        }
+        return &dec, nil
 }
 
 func (c *Client) CompileRule(tenantID, rule string) (string, error) {
-	resp, err := c.post("/compile", map[string]string{"tenantID": tenantID, "rule": rule})
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
-	}
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-	return string(body), nil
+        resp, err := c.post("/compile", map[string]string{"tenantID": tenantID, "rule": rule})
+        if err != nil {
+                return "", err
+        }
+        defer resp.Body.Close()
+        if resp.StatusCode != http.StatusOK {
+                body, _ := io.ReadAll(resp.Body)
+                return "", fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+        }
+        body, err := io.ReadAll(resp.Body)
+        if err != nil {
+                return "", err
+        }
+        return string(body), nil
 }
 
 func (c *Client) ValidatePolicy(tenantID, policy string) error {
-	resp, err := c.post("/validate-policy", map[string]string{"tenantID": tenantID, "policy": policy})
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
-	}
-	return nil
+        resp, err := c.post("/validate-policy", map[string]string{"tenantID": tenantID, "policy": policy})
+        if err != nil {
+                return err
+        }
+        defer resp.Body.Close()
+        if resp.StatusCode != http.StatusOK {
+                body, _ := io.ReadAll(resp.Body)
+                return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+        }
+        return nil
 }

--- a/sdk/go/sdk_test.go
+++ b/sdk/go/sdk_test.go
@@ -1,43 +1,56 @@
 package sdk
 
 import (
-	"encoding/json"
-	"net/http"
-	"net/http/httptest"
-	"testing"
+        "encoding/json"
+        "net/http"
+        "net/http/httptest"
+        "testing"
 )
 
 type checkAccessResponse struct {
-	Allow    bool   `json:"allow"`
-	PolicyID string `json:"policyID"`
-	Reason   string `json:"reason"`
+        Allow    bool   `json:"allow"`
+        PolicyID string `json:"policyID"`
+        Reason   string `json:"reason"`
+}
+
+type simulateResponse struct {
+        Allow  bool   `json:"allow"`
+        Reason string `json:"reason"`
 }
 
 func TestClient(t *testing.T) {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/check-access", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(checkAccessResponse{Allow: true, PolicyID: "p1", Reason: "ok"})
-	})
-	mux.HandleFunc("/compile", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("policy: allow"))
-	})
-	mux.HandleFunc("/validate-policy", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("policy is valid"))
-	})
-	srv := httptest.NewServer(mux)
-	defer srv.Close()
+        mux := http.NewServeMux()
+        mux.HandleFunc("/check-access", func(w http.ResponseWriter, r *http.Request) {
+                w.Header().Set("Content-Type", "application/json")
+                json.NewEncoder(w).Encode(checkAccessResponse{Allow: true, PolicyID: "p1", Reason: "ok"})
+        })
+        mux.HandleFunc("/simulate", func(w http.ResponseWriter, r *http.Request) {
+                w.Header().Set("Content-Type", "application/json")
+                json.NewEncoder(w).Encode(simulateResponse{Allow: false, Reason: "sim"})
+        })
+        mux.HandleFunc("/compile", func(w http.ResponseWriter, r *http.Request) {
+                w.Write([]byte("policy: allow"))
+        })
+        mux.HandleFunc("/validate-policy", func(w http.ResponseWriter, r *http.Request) {
+                w.WriteHeader(http.StatusOK)
+                w.Write([]byte("policy is valid"))
+        })
+        srv := httptest.NewServer(mux)
+        defer srv.Close()
 
-	c := NewClient(srv.URL)
-	dec, err := c.CheckAccess(AccessRequest{TenantID: "t", Subject: "s", Resource: "r", Action: "a"})
-	if err != nil || !dec.Allow {
-		t.Fatalf("CheckAccess failed: %v", err)
-	}
-	if _, err := c.CompileRule("t", "rule"); err != nil {
-		t.Fatalf("CompileRule failed: %v", err)
-	}
-	if err := c.ValidatePolicy("t", "policy"); err != nil {
-		t.Fatalf("ValidatePolicy failed: %v", err)
-	}
+        c := NewClient(srv.URL)
+        dec, err := c.CheckAccess(AccessRequest{TenantID: "t", Subject: "s", Resource: "r", Action: "a"})
+        if err != nil || !dec.Allow {
+                t.Fatalf("CheckAccess failed: %v", err)
+        }
+        sim, err := c.SimulateAccess(SimulationRequest{TenantID: "t", Subject: "s", Resource: "r", Action: "a"})
+        if err != nil || sim.Allow {
+                t.Fatalf("SimulateAccess failed: %v", err)
+        }
+        if _, err := c.CompileRule("t", "rule"); err != nil {
+                t.Fatalf("CompileRule failed: %v", err)
+        }
+        if err := c.ValidatePolicy("t", "policy"); err != nil {
+                t.Fatalf("ValidatePolicy failed: %v", err)
+        }
 }

--- a/sdk/python/authorization.py
+++ b/sdk/python/authorization.py
@@ -1,25 +1,33 @@
 import json
 from urllib import request
+from urllib.parse import urljoin
 
 
 class Client:
-    def __init__(self, base_url: str):
-        self.base_url = base_url.rstrip('/')
+    def __init__(self, base_url: str, token: str | None = None):
+        self.base_url = base_url.rstrip('/') + '/'
+        self.token = token
 
     def _post(self, path: str, data: dict) -> tuple[int, str]:
         payload = json.dumps(data).encode('utf-8')
         req = request.Request(
-            self.base_url + path,
+            urljoin(self.base_url, path.lstrip('/')),
             data=payload,
-            headers={'Content-Type': 'application/json'},
+            headers=self._headers(),
             method='POST',
         )
         with request.urlopen(req) as resp:
             body = resp.read().decode('utf-8')
             return resp.status, body
 
+    def _headers(self) -> dict:
+        headers = {'Content-Type': 'application/json'}
+        if self.token:
+            headers['Authorization'] = f'Bearer {self.token}'
+        return headers
+
     def check_access(self, tenant_id: str, subject: str, resource: str, action: str, conditions: dict | None = None) -> dict:
-        status, body = self._post('/check-access', {
+        status, body = self._post('check-access', {
             'tenantID': tenant_id,
             'subject': subject,
             'resource': resource,
@@ -30,15 +38,26 @@ class Client:
             raise RuntimeError(f'unexpected status {status}: {body}')
         return json.loads(body)
 
+    def simulate_access(self, tenant_id: str, subject: str, resource: str, action: str, context: dict | None = None) -> dict:
+        status, body = self._post('simulate', {
+            'tenantID': tenant_id,
+            'subject': subject,
+            'resource': resource,
+            'action': action,
+            'context': context or {},
+        })
+        if status != 200:
+            raise RuntimeError(f'unexpected status {status}: {body}')
+        return json.loads(body)
+
     def compile_rule(self, tenant_id: str, rule: str) -> str:
-        status, body = self._post('/compile', {'tenantID': tenant_id, 'rule': rule})
+        status, body = self._post('compile', {'tenantID': tenant_id, 'rule': rule})
         if status != 200:
             raise RuntimeError(f'unexpected status {status}: {body}')
         return body
 
     def validate_policy(self, tenant_id: str, policy: str) -> str:
-        status, body = self._post('/validate-policy', {'tenantID': tenant_id, 'policy': policy})
+        status, body = self._post('validate-policy', {'tenantID': tenant_id, 'policy': policy})
         if status != 200:
             raise RuntimeError(f'unexpected status {status}: {body}')
         return body
-

--- a/sdk/python/test_authorization.py
+++ b/sdk/python/test_authorization.py
@@ -3,7 +3,7 @@ import threading
 import unittest
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
-from authorization import Client
+from sdk.python.authorization import Client
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -21,6 +21,11 @@ class Handler(BaseHTTPRequestHandler):
             self.send_response(200)
             self.end_headers()
             self.wfile.write(b'policy is valid')
+        elif self.path == '/simulate':
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self.wfile.write(b'{"allow": false, "reason": "simulated"}')
         else:
             self.send_response(404)
             self.end_headers()
@@ -32,7 +37,7 @@ class TestClient(unittest.TestCase):
         cls.server = HTTPServer(('localhost', 0), Handler)
         cls.port = cls.server.server_address[1]
         cls.thread = threading.Thread(target=cls.server.serve_forever)
-        cls.thread.setDaemon(True)
+        cls.thread.daemon = True
         cls.thread.start()
 
     @classmethod
@@ -41,7 +46,7 @@ class TestClient(unittest.TestCase):
         cls.thread.join()
 
     def setUp(self):
-        self.client = Client(f'http://localhost:{self.port}')
+        self.client = Client(f'http://localhost:{self.port}', token='abc123')
 
     def test_check_access(self):
         decision = self.client.check_access('t', 's', 'r', 'a')
@@ -55,7 +60,11 @@ class TestClient(unittest.TestCase):
         resp = self.client.validate_policy('t', 'policy')
         self.assertIn('valid', resp)
 
+    def test_simulate_access(self):
+        decision = self.client.simulate_access('t', 's', 'r', 'a', {'k': 'v'})
+        self.assertFalse(decision['allow'])
+        self.assertEqual('simulated', decision['reason'])
+
 
 if __name__ == '__main__':
     unittest.main()
-


### PR DESCRIPTION
## Summary
- replace the Node.js SDK with HTTP-based helpers that mirror service routes and add node:test coverage
- extend Go and Python SDKs with simulate access support, bearer headers, and import-friendly packaging updates
- refresh SDK README with aligned configuration and usage instructions across languages

## Testing
- go test ./sdk/go
- python3 -m pytest sdk/python/test_authorization.py
- node --test sdk/AuthorizationSDK.test.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693467cbdaa0832cb33a288b96465e54)