### PR TITLE
Add client-credentials /token endpoint with policy hook integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ cp .env.example .env
 ```
 CLIENT_ID=my-client-id
 CLIENT_SECRET=my-client-secret
+TOKEN_SIGNING_KEY=dev-secret
+TOKEN_ISSUER=authorization-service
+TOKEN_AUDIENCE=authorization-service
 PORT=8080
 OIDC_ISSUERS=http://localhost:8081/realms/master
 OIDC_AUDIENCES=authorization-service
@@ -66,6 +69,17 @@ Start the service:
 
 ```sh
 docker compose up --build
+```
+
+### OAuth Token Quickstart
+
+Issue a client credentials token:
+
+```sh
+curl -s -X POST http://localhost:8080/token \
+  -u "$CLIENT_ID:$CLIENT_SECRET" \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d 'grant_type=client_credentials&tenant_id=default&scope=read'
 ```
 
 ### RBAC Quickstart
@@ -198,6 +212,10 @@ curl -s -X POST http://localhost:8080/check-access \
 - [Simulation](docs/simulation.md)
 - [OIDC](docs/oidc.md)
 - [Observability](docs/observability.md)
+- [Policy Hooks](docs/policy-hooks.md)
+- [Agent Delegation](docs/agent-delegation.md)
+- [CIBA Stub](docs/ciba-stub.md)
+- [Security](docs/security.md)
 - [Deployment](docs/deployment.md)
 - [Contributing](docs/contributing.md)
 - [Architecture](docs/architecture.md) · [Flows](docs/flows.md)

--- a/api/api.go
+++ b/api/api.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/bradtumy/authorization-service/internal/logger"
 	"github.com/bradtumy/authorization-service/internal/middleware"
+	"github.com/bradtumy/authorization-service/internal/oauth"
 	"github.com/bradtumy/authorization-service/pkg/contextprovider"
 	"github.com/bradtumy/authorization-service/pkg/graph"
 	"github.com/bradtumy/authorization-service/pkg/identity"
@@ -36,6 +37,7 @@ var (
 	policyBackend string
 	compiler      policycompiler.Compiler
 	auditLogger   *logger.Logger
+	tokenService  *oauth.TokenService
 	policyEval    = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "policy_eval_count",
@@ -108,6 +110,7 @@ func init() {
 	compiler = policycompiler.NewOpenAICompiler(os.Getenv("OPENAI_API_KEY"))
 	lvl := logger.ParseLevel(os.Getenv("LOG_LEVEL"))
 	auditLogger = logger.New(os.Stdout, lvl)
+	tokenService = newTokenService()
 	prometheus.MustRegister(policyEval)
 	tracer = otel.Tracer("authorization-service")
 	contextProviders = contextprovider.Chain{
@@ -220,22 +223,24 @@ func SetupRouter(p identity.Provider) *mux.Router {
 	router.Use(middleware.TracingMiddleware)
 	router.Use(middleware.CorrelationMiddleware)
 	router.Use(middleware.MetricsMiddleware)
-	router.Use(middleware.JWTMiddleware)
-	router.HandleFunc("/authorize", Authorize).Methods("POST")
-	router.HandleFunc("/check-access", CheckAccess).Methods("POST")
-	router.HandleFunc("/simulate", SimulateAccess).Methods("POST")
-	router.HandleFunc("/reload", ReloadPolicies).Methods("POST")
-	router.HandleFunc("/compile", CompileRule).Methods("POST")
-	router.HandleFunc("/validate-policy", ValidatePolicy).Methods("POST")
-	router.HandleFunc("/tenant/create", CreateTenant).Methods("POST")
-	router.HandleFunc("/tenant/delete", DeleteTenant).Methods("POST")
-	router.HandleFunc("/tenant/list", ListTenants).Methods("GET")
-	router.HandleFunc("/user/create", CreateUser).Methods("POST")
-	router.HandleFunc("/user/assign-role", AssignRole).Methods("POST")
-	router.HandleFunc("/user/delete", DeleteUser).Methods("POST")
-	router.HandleFunc("/user/list", ListUsers).Methods("GET")
-	router.HandleFunc("/user/get", GetUser).Methods("GET")
-	router.Handle("/metrics", promhttp.Handler()).Methods("GET")
+	router.HandleFunc("/token", Token).Methods("POST")
+	protected := router.NewRoute().Subrouter()
+	protected.Use(middleware.JWTMiddleware)
+	protected.HandleFunc("/authorize", Authorize).Methods("POST")
+	protected.HandleFunc("/check-access", CheckAccess).Methods("POST")
+	protected.HandleFunc("/simulate", SimulateAccess).Methods("POST")
+	protected.HandleFunc("/reload", ReloadPolicies).Methods("POST")
+	protected.HandleFunc("/compile", CompileRule).Methods("POST")
+	protected.HandleFunc("/validate-policy", ValidatePolicy).Methods("POST")
+	protected.HandleFunc("/tenant/create", CreateTenant).Methods("POST")
+	protected.HandleFunc("/tenant/delete", DeleteTenant).Methods("POST")
+	protected.HandleFunc("/tenant/list", ListTenants).Methods("GET")
+	protected.HandleFunc("/user/create", CreateUser).Methods("POST")
+	protected.HandleFunc("/user/assign-role", AssignRole).Methods("POST")
+	protected.HandleFunc("/user/delete", DeleteUser).Methods("POST")
+	protected.HandleFunc("/user/list", ListUsers).Methods("GET")
+	protected.HandleFunc("/user/get", GetUser).Methods("GET")
+	protected.Handle("/metrics", promhttp.Handler()).Methods("GET")
 	return router
 }
 

--- a/api/token.go
+++ b/api/token.go
@@ -1,0 +1,119 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/bradtumy/authorization-service/internal/oauth"
+	"github.com/bradtumy/authorization-service/internal/policyhook"
+)
+
+func newTokenService() *oauth.TokenService {
+	issuer, err := oauth.NewIssuerFromEnv()
+	if err != nil {
+		return nil
+	}
+	failClosed := true
+	if v := strings.ToLower(os.Getenv("POLICY_HOOKS_FAIL_CLOSED")); v != "" {
+		failClosed = v != "false"
+	}
+	var pre policyhook.PreIssueHook = policyhook.NoopHook{}
+	var post policyhook.PostIssueHook = policyhook.NoopHook{}
+	if strings.ToLower(os.Getenv("POLICY_HOOKS_ENABLED")) == "true" {
+		allowedHosts := strings.Split(os.Getenv("POLICY_HOOKS_ALLOWED_HOSTS"), ",")
+		timeout := 3 * time.Second
+		if raw := os.Getenv("POLICY_HOOKS_TIMEOUT"); raw != "" {
+			if parsed, err := time.ParseDuration(raw); err == nil {
+				timeout = parsed
+			}
+		}
+		client := policyhook.HTTPClient{
+			Endpoint:     os.Getenv("POLICY_HOOKS_ENDPOINT"),
+			Timeout:      timeout,
+			AllowedHosts: filterEmpty(allowedHosts),
+		}
+		pre = client
+		post = client
+	}
+	service := oauth.TokenService{
+		Clients:    oauth.EnvClientStore{},
+		Issuer:     issuer,
+		PreHook:    pre,
+		PostHook:   post,
+		FailClosed: failClosed,
+	}
+	return &service
+}
+
+func Token(w http.ResponseWriter, r *http.Request) {
+	if tokenService == nil {
+		http.Error(w, "token service not configured", http.StatusInternalServerError)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "invalid form", http.StatusBadRequest)
+		return
+	}
+	grantType := r.FormValue("grant_type")
+	if grantType != "client_credentials" {
+		http.Error(w, "unsupported grant_type", http.StatusBadRequest)
+		return
+	}
+	clientID, clientSecret, err := clientCredentials(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+	if !tokenService.Clients.Validate(clientID, clientSecret) {
+		http.Error(w, "invalid client", http.StatusUnauthorized)
+		return
+	}
+	scope := strings.Fields(r.FormValue("scope"))
+	tenantID := r.FormValue("tenant_id")
+	if tenantID == "" {
+		http.Error(w, "tenant_id is required", http.StatusBadRequest)
+		return
+	}
+	req := oauth.TokenRequest{
+		GrantType: "client_credentials",
+		ClientID:  clientID,
+		Scopes:    scope,
+		TenantID:  tenantID,
+		Audience:  r.FormValue("audience"),
+		Subject:   clientID,
+	}
+	resp, err := tokenService.IssueClientCredentials(r.Context(), req)
+	if err != nil {
+		http.Error(w, "token issuance failed", http.StatusForbidden)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+func clientCredentials(r *http.Request) (string, string, error) {
+	if id, secret, ok := r.BasicAuth(); ok {
+		return id, secret, nil
+	}
+	id := r.FormValue("client_id")
+	secret := r.FormValue("client_secret")
+	if id == "" || secret == "" {
+		return "", "", errors.New("missing client credentials")
+	}
+	return id, secret, nil
+}
+
+func filterEmpty(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		if strings.TrimSpace(v) == "" {
+			continue
+		}
+		out = append(out, strings.TrimSpace(v))
+	}
+	return out
+}

--- a/api/token_hook_test.go
+++ b/api/token_hook_test.go
@@ -1,0 +1,73 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/bradtumy/authorization-service/pkg/identity/local"
+	"github.com/bradtumy/authorization-service/pkg/user"
+	"github.com/golang-jwt/jwt/v4"
+)
+
+func TestTokenPolicyHook(t *testing.T) {
+	pdp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"allow":           true,
+			"scopes_to_issue": []string{"hooked"},
+			"claims_to_embed": map[string]interface{}{"act": map[string]interface{}{"sub": "agent"}},
+		})
+	}))
+	defer pdp.Close()
+
+	os.Setenv("TOKEN_SIGNING_KEY", "test-secret")
+	os.Setenv("CLIENT_ID", "client")
+	os.Setenv("CLIENT_SECRET", "secret")
+	os.Setenv("POLICY_HOOKS_ENABLED", "true")
+	os.Setenv("POLICY_HOOKS_ENDPOINT", pdp.URL)
+	os.Setenv("POLICY_HOOKS_ALLOWED_HOSTS", "")
+	tokenService = newTokenService()
+
+	idp := local.New(false)
+	user.SetProvider(idp)
+	router := SetupRouter(idp)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+	form.Set("tenant_id", "acme")
+	form.Set("scope", "ignored")
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth("client", "secret")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 got %d", resp.StatusCode)
+	}
+	var out struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	claims := jwt.MapClaims{}
+	_, _, err = new(jwt.Parser).ParseUnverified(out.AccessToken, claims)
+	if err != nil {
+		t.Fatalf("parse token: %v", err)
+	}
+	if scope, ok := claims["scope"].([]interface{}); !ok || len(scope) != 1 || scope[0] != "hooked" {
+		t.Fatalf("expected hooked scope, got %v", claims["scope"])
+	}
+	if _, ok := claims["act"].(map[string]interface{}); !ok {
+		t.Fatalf("expected act claim")
+	}
+}

--- a/api/token_test.go
+++ b/api/token_test.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/bradtumy/authorization-service/pkg/identity/local"
+	"github.com/bradtumy/authorization-service/pkg/user"
+)
+
+type tokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int64  `json:"expires_in"`
+	Scope       string `json:"scope"`
+}
+
+func TestTokenClientCredentials(t *testing.T) {
+	os.Setenv("TOKEN_SIGNING_KEY", "test-secret")
+	os.Setenv("CLIENT_ID", "client")
+	os.Setenv("CLIENT_SECRET", "secret")
+	os.Setenv("POLICY_HOOKS_ENABLED", "false")
+	tokenService = newTokenService()
+
+	idp := local.New(false)
+	user.SetProvider(idp)
+	router := SetupRouter(idp)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+	form.Set("tenant_id", "acme")
+	form.Set("scope", "read write")
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth("client", "secret")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 got %d", resp.StatusCode)
+	}
+	var out tokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if out.AccessToken == "" || out.TokenType != "bearer" || out.ExpiresIn == 0 {
+		t.Fatalf("unexpected response: %+v", out)
+	}
+}

--- a/docs/agent-delegation.md
+++ b/docs/agent-delegation.md
@@ -1,0 +1,25 @@
+# Agent Delegation via OAuth
+
+## Overview
+This repo now supports issuing OAuth tokens for agents via the `client_credentials` grant. Delegation semantics (actor vs subject) are embedded using the `act` claim when provided by policy hooks.
+
+## Token Issuance
+Use the `/token` endpoint with client credentials and a tenant identifier:
+
+```sh
+curl -s -X POST http://localhost:8080/token \
+  -u "$CLIENT_ID:$CLIENT_SECRET" \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d 'grant_type=client_credentials&tenant_id=acme&scope=read'
+```
+
+## Delegation Claims
+Policy hooks can embed delegation metadata using the `act` claim, for example:
+
+```json
+{"act": {"sub": "agent"}}
+```
+
+## Notes
+- Token exchange (RFC 8693) is deferred; this MVP focuses on agent tokens minted directly for client credentials.
+- Keep delegated token TTLs short and scopes narrowly scoped using policy hooks.

--- a/docs/ciba-stub.md
+++ b/docs/ciba-stub.md
@@ -1,0 +1,17 @@
+# CIBA Consent Escalation (Stub)
+
+## Status
+CIBA is not implemented in this repository yet. This document defines the intended contract for a future implementation.
+
+## Intended Endpoints
+- `POST /backchannel/authentication` to create a backchannel authentication request.
+- `POST /token` with `grant_type=urn:openid:params:grant-type:ciba` to poll for tokens.
+
+## MVP Stub Expectations
+- Authentication of CIBA clients using the same client registry as `/token`.
+- Local/dev approval simulation via a simple approval store or in-memory map.
+- Audit log entries on request creation, approval, and token issuance.
+
+## Deferred Items
+- Binding between auth request and token (nonce, jti).
+- Push mode and callback delivery.

--- a/docs/policy-hooks.md
+++ b/docs/policy-hooks.md
@@ -1,0 +1,47 @@
+# Policy Hooks
+
+## Overview
+Policy hooks let the authorization service consult an external PDP before issuing tokens. The hook can deny issuance, narrow scopes, and add bounded claims.
+
+## Configuration
+Set environment variables:
+
+| Variable | Description |
+| --- | --- |
+| `POLICY_HOOKS_ENABLED` | Enable pre-issue hook (`true`/`false`). |
+| `POLICY_HOOKS_ENDPOINT` | PDP HTTP endpoint for pre-issue decisions. |
+| `POLICY_HOOKS_TIMEOUT` | Request timeout (e.g. `3s`). |
+| `POLICY_HOOKS_ALLOWED_HOSTS` | Comma-separated host allowlist for SSRF protection. |
+| `POLICY_HOOKS_FAIL_CLOSED` | Fail issuance on hook error (`true` default). |
+
+## Request Contract
+The service posts JSON to the PDP:
+
+```json
+{
+  "grant_type": "client_credentials",
+  "client_id": "agent-client",
+  "subject": "agent-client",
+  "requested_scopes": ["read"],
+  "audience": "authorization-service",
+  "tenant_id": "acme",
+  "requested_ttl_seconds": 3600
+}
+```
+
+## Response Contract
+The PDP responds with:
+
+```json
+{
+  "allow": true,
+  "scopes_to_issue": ["read"],
+  "claims_to_embed": {"act": {"sub": "agent"}},
+  "ttl_override_seconds": 900,
+  "deny_reason": "policy"
+}
+```
+
+## Notes
+- Decision outcomes and detailed reasoning remain in the PDP/AAAP layer.
+- Hook failures are fail-closed by default; set `POLICY_HOOKS_FAIL_CLOSED=false` for dev-only fail-open behavior.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,19 @@
+# Security Considerations
+
+## Token Issuance
+- Rotate `TOKEN_SIGNING_KEY` regularly and store it securely (KMS/secret manager).
+- Restrict `TOKEN_AUDIENCE` and `TOKEN_ISSUER` to trusted values.
+- Set short TTLs for agent tokens; override with policy hooks only when necessary.
+
+## Policy Hooks
+- Use `POLICY_HOOKS_ALLOWED_HOSTS` to prevent SSRF.
+- Enforce timeouts and fail-closed behavior for sensitive grants.
+- Do not log PII or secret claims returned by the PDP.
+
+## Delegation
+- Use `act` claims to represent actor-subject relationships.
+- Ensure delegated tokens have reduced TTLs and narrowed scopes.
+
+## CIBA (Deferred)
+- Bind auth requests to token issuance using nonces and audit logs.
+- Rate limit polling and protect against phishing attacks.

--- a/internal/oauth/client_store.go
+++ b/internal/oauth/client_store.go
@@ -1,0 +1,12 @@
+package oauth
+
+import "os"
+
+// EnvClientStore validates a single client from environment variables.
+type EnvClientStore struct{}
+
+func (EnvClientStore) Validate(clientID, clientSecret string) bool {
+	expectedID := os.Getenv("CLIENT_ID")
+	expectedSecret := os.Getenv("CLIENT_SECRET")
+	return expectedID != "" && expectedSecret != "" && clientID == expectedID && clientSecret == expectedSecret
+}

--- a/internal/oauth/issuer.go
+++ b/internal/oauth/issuer.go
@@ -1,0 +1,74 @@
+package oauth
+
+import (
+	"errors"
+	"os"
+	"time"
+
+	"github.com/bradtumy/authorization-service/pkg/oidc"
+	"github.com/golang-jwt/jwt/v4"
+)
+
+// Issuer mints signed JWTs for access tokens.
+type Issuer struct {
+	SigningKey []byte
+	Issuer     string
+	Audience   string
+	TTL        time.Duration
+}
+
+// NewIssuerFromEnv builds an issuer from environment variables.
+func NewIssuerFromEnv() (Issuer, error) {
+	key := os.Getenv("TOKEN_SIGNING_KEY")
+	if key == "" {
+		return Issuer{}, errors.New("TOKEN_SIGNING_KEY is required")
+	}
+	iss := os.Getenv("TOKEN_ISSUER")
+	if iss == "" {
+		iss = "authorization-service"
+	}
+	aud := os.Getenv("TOKEN_AUDIENCE")
+	if aud == "" {
+		aud = "authorization-service"
+	}
+	ttl := time.Hour
+	if raw := os.Getenv("TOKEN_TTL"); raw != "" {
+		if parsed, err := time.ParseDuration(raw); err == nil {
+			ttl = parsed
+		}
+	}
+	return Issuer{SigningKey: []byte(key), Issuer: iss, Audience: aud, TTL: ttl}, nil
+}
+
+// Issue creates a signed JWT access token.
+func (i Issuer) Issue(req TokenRequest, scopes []string, claims map[string]interface{}, ttlOverride time.Duration) (string, int64, error) {
+	ttl := i.TTL
+	if req.RequestedTTL > 0 {
+		ttl = req.RequestedTTL
+	}
+	if ttlOverride > 0 {
+		ttl = ttlOverride
+	}
+	now := time.Now()
+	exp := now.Add(ttl).Unix()
+	base := jwt.MapClaims{
+		"iss":       i.Issuer,
+		"sub":       req.Subject,
+		"aud":       req.Audience,
+		"iat":       now.Unix(),
+		"exp":       exp,
+		"client_id": req.ClientID,
+	}
+	if req.TenantID != "" {
+		base[oidc.TenantClaim()] = req.TenantID
+	}
+	if len(scopes) > 0 {
+		base["scope"] = scopes
+	}
+	for k, v := range claims {
+		base[k] = v
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, base)
+	str, err := tok.SignedString(i.SigningKey)
+	return str, exp - now.Unix(), err
+}

--- a/internal/oauth/service.go
+++ b/internal/oauth/service.go
@@ -1,0 +1,77 @@
+package oauth
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/bradtumy/authorization-service/internal/policyhook"
+)
+
+// TokenService issues OAuth tokens.
+type TokenService struct {
+	Clients    ClientStore
+	Issuer     Issuer
+	PreHook    policyhook.PreIssueHook
+	PostHook   policyhook.PostIssueHook
+	FailClosed bool
+}
+
+// IssueClientCredentials issues a token for client credentials flow.
+func (s TokenService) IssueClientCredentials(ctx context.Context, req TokenRequest) (TokenResponse, error) {
+	if s.Clients == nil {
+		return TokenResponse{}, errors.New("client store is not configured")
+	}
+	if req.ClientID == "" {
+		return TokenResponse{}, errors.New("client_id is required")
+	}
+	if req.Audience == "" {
+		req.Audience = s.Issuer.Audience
+	}
+	if req.Subject == "" {
+		req.Subject = req.ClientID
+	}
+	if s.PreHook != nil {
+		decision, err := s.PreHook.PreIssue(ctx, policyhook.Request{
+			GrantType:       req.GrantType,
+			ClientID:        req.ClientID,
+			Subject:         req.Subject,
+			RequestedScopes: req.Scopes,
+			Audience:        req.Audience,
+			TenantID:        req.TenantID,
+			RequestedTTL:    int64(req.RequestedTTL.Seconds()),
+		})
+		if err != nil {
+			if s.FailClosed {
+				return TokenResponse{}, err
+			}
+		} else if !decision.Allow {
+			return TokenResponse{}, errors.New(decision.DenyReason)
+		} else if len(decision.Scopes) > 0 {
+			req.Scopes = decision.Scopes
+		}
+		claims := decision.Claims
+		if claims == nil {
+			claims = map[string]interface{}{}
+		}
+		if s.PostHook != nil {
+			claims, err = s.PostHook.PostIssue(ctx, claims, policyhook.Request{GrantType: req.GrantType, ClientID: req.ClientID})
+			if err != nil && s.FailClosed {
+				return TokenResponse{}, err
+			}
+		}
+		ttlOverride := time.Duration(decision.TTLSeconds) * time.Second
+		accessToken, expiresIn, err := s.Issuer.Issue(req, req.Scopes, claims, ttlOverride)
+		if err != nil {
+			return TokenResponse{}, err
+		}
+		return TokenResponse{AccessToken: accessToken, TokenType: "bearer", ExpiresIn: expiresIn, Scope: strings.Join(req.Scopes, " ")}, nil
+	}
+
+	accessToken, expiresIn, err := s.Issuer.Issue(req, req.Scopes, map[string]interface{}{}, 0)
+	if err != nil {
+		return TokenResponse{}, err
+	}
+	return TokenResponse{AccessToken: accessToken, TokenType: "bearer", ExpiresIn: expiresIn, Scope: strings.Join(req.Scopes, " ")}, nil
+}

--- a/internal/oauth/types.go
+++ b/internal/oauth/types.go
@@ -1,0 +1,27 @@
+package oauth
+
+import "time"
+
+// TokenRequest represents an OAuth token request.
+type TokenRequest struct {
+	GrantType    string
+	ClientID     string
+	Scopes       []string
+	TenantID     string
+	Audience     string
+	Subject      string
+	RequestedTTL time.Duration
+}
+
+// TokenResponse is a minimal OAuth token response.
+type TokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int64  `json:"expires_in"`
+	Scope       string `json:"scope,omitempty"`
+}
+
+// ClientStore validates client credentials.
+type ClientStore interface {
+	Validate(clientID, clientSecret string) bool
+}

--- a/internal/policyhook/http_client.go
+++ b/internal/policyhook/http_client.go
@@ -1,0 +1,98 @@
+package policyhook
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// HTTPClient calls an external policy decision point.
+type HTTPClient struct {
+	Endpoint     string
+	Timeout      time.Duration
+	AllowedHosts []string
+	HTTPClient   *http.Client
+}
+
+// PreIssue sends a policy consult request to the PDP endpoint.
+func (c HTTPClient) PreIssue(ctx context.Context, req Request) (Decision, error) {
+	if c.Endpoint == "" {
+		return Decision{}, errors.New("policy hook endpoint is not configured")
+	}
+	u, err := url.Parse(c.Endpoint)
+	if err != nil {
+		return Decision{}, err
+	}
+	if len(c.AllowedHosts) > 0 {
+		host := u.Hostname()
+		allowed := false
+		for _, h := range c.AllowedHosts {
+			if strings.EqualFold(strings.TrimSpace(h), host) {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return Decision{}, errors.New("policy hook host not allowed")
+		}
+	}
+	client := c.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: c.Timeout}
+	}
+	if client.Timeout == 0 {
+		client.Timeout = c.Timeout
+	}
+	if client.Timeout == 0 {
+		client.Timeout = 3 * time.Second
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return Decision{}, err
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, client.Timeout)
+	defer cancel()
+	httpReq, err := http.NewRequestWithContext(reqCtx, http.MethodPost, c.Endpoint, bytes.NewReader(body))
+	if err != nil {
+		return Decision{}, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		if isTimeout(err) {
+			return Decision{}, errors.New("policy hook timeout")
+		}
+		return Decision{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return Decision{}, errors.New("policy hook denied")
+	}
+	var decision Decision
+	if err := json.NewDecoder(resp.Body).Decode(&decision); err != nil {
+		return Decision{}, err
+	}
+	return decision, nil
+}
+
+// PostIssue returns claims unchanged for HTTPClient.
+func (c HTTPClient) PostIssue(ctx context.Context, claims map[string]interface{}, req Request) (map[string]interface{}, error) {
+	return claims, nil
+}
+
+func isTimeout(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return netErr.Timeout()
+	}
+	return false
+}

--- a/internal/policyhook/http_client_test.go
+++ b/internal/policyhook/http_client_test.go
@@ -1,0 +1,48 @@
+package policyhook
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestHTTPClientPreIssue(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req Request
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if req.ClientID != "client" {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		json.NewEncoder(w).Encode(Decision{Allow: true, Scopes: []string{"read"}})
+	}))
+	defer srv.Close()
+
+	client := HTTPClient{Endpoint: srv.URL, Timeout: 500 * time.Millisecond}
+	decision, err := client.PreIssue(context.Background(), Request{ClientID: "client"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !decision.Allow || len(decision.Scopes) != 1 || decision.Scopes[0] != "read" {
+		t.Fatalf("unexpected decision: %+v", decision)
+	}
+}
+
+func TestHTTPClientPreIssueHostAllowlist(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(Decision{Allow: true})
+	}))
+	defer srv.Close()
+
+	client := HTTPClient{Endpoint: srv.URL, Timeout: time.Second, AllowedHosts: []string{"example.com"}}
+	_, err := client.PreIssue(context.Background(), Request{ClientID: "client"})
+	if err == nil {
+		t.Fatalf("expected allowlist error")
+	}
+}

--- a/internal/policyhook/noop.go
+++ b/internal/policyhook/noop.go
@@ -1,0 +1,14 @@
+package policyhook
+
+import "context"
+
+// NoopHook allows all requests and makes no modifications.
+type NoopHook struct{}
+
+func (NoopHook) PreIssue(ctx context.Context, req Request) (Decision, error) {
+	return Decision{Allow: true}, nil
+}
+
+func (NoopHook) PostIssue(ctx context.Context, claims map[string]interface{}, req Request) (map[string]interface{}, error) {
+	return claims, nil
+}

--- a/internal/policyhook/types.go
+++ b/internal/policyhook/types.go
@@ -1,0 +1,37 @@
+package policyhook
+
+import "context"
+
+// Decision represents a policy hook decision.
+type Decision struct {
+	Allow      bool                   `json:"allow"`
+	Scopes     []string               `json:"scopes_to_issue,omitempty"`
+	Claims     map[string]interface{} `json:"claims_to_embed,omitempty"`
+	TTLSeconds int64                  `json:"ttl_override_seconds,omitempty"`
+	DenyReason string                 `json:"deny_reason,omitempty"`
+	DecisionID string                 `json:"decision_id,omitempty"`
+}
+
+// Request captures the context sent to a policy hook.
+type Request struct {
+	GrantType       string            `json:"grant_type"`
+	ClientID        string            `json:"client_id"`
+	Subject         string            `json:"subject,omitempty"`
+	Actor           string            `json:"actor,omitempty"`
+	RequestedScopes []string          `json:"requested_scopes,omitempty"`
+	Audience        string            `json:"audience,omitempty"`
+	Resource        string            `json:"resource,omitempty"`
+	TenantID        string            `json:"tenant_id,omitempty"`
+	RequestedTTL    int64             `json:"requested_ttl_seconds,omitempty"`
+	TokenExchange   map[string]string `json:"token_exchange,omitempty"`
+}
+
+// PreIssueHook consults policy before issuing a token.
+type PreIssueHook interface {
+	PreIssue(ctx context.Context, req Request) (Decision, error)
+}
+
+// PostIssueHook mutates the token claims after issuance.
+type PostIssueHook interface {
+	PostIssue(ctx context.Context, claims map[string]interface{}, req Request) (map[string]interface{}, error)
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal OAuth client-credentials token issuance path so agents can obtain scoped access tokens from the service. 
- Allow external policy decision points (PDP) to influence token issuance (deny, narrow scopes, embed claims, override TTL) to support delegation and runtime policy controls. 
- Keep existing management and RBAC endpoints protected behind JWT authentication while exposing a dedicated `/token` endpoint for issuance.

### Description
- Add a new `/token` handler and `newTokenService` wiring in `api/token.go` and register it in the router while moving protected endpoints into a JWT-protected subrouter. 
- Implement a minimal OAuth token service (`internal/oauth`) including `TokenRequest`/`TokenResponse`, an `EnvClientStore`, an `Issuer` that signs JWTs from env vars, and a `TokenService` that consults policy hooks before issuing tokens. 
- Add policy hook interfaces and a HTTP client (`internal/policyhook`) with timeout, host allowlist (SSRF protection), and JSON request/response handling, plus a noop implementation. 
- Add documentation (`docs/*.md`) and README updates describing policy hooks, agent delegation, a CIBA stub, and security considerations, and include tests for the policy hook client and token endpoint behavior.

### Testing
- Added unit tests `internal/policyhook/http_client_test.go` and integration-style tests `api/token_test.go` and `api/token_hook_test.go` that exercise the PDP consult and token issuance flows, but `go test` runs in this environment did not complete. 
- Attempted `go test ./...` which stalled and did not finish in this environment. 
- Attempted `go test ./api ./internal/policyhook` and `go test ./internal/policyhook -run TestHTTPClientPreIssue -count=1`, both of which did not complete due to environment/toolchain stalls.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698762a55eec832cab24bebdfd80add7)